### PR TITLE
Avoid system cd call

### DIFF
--- a/R/app_status.R
+++ b/R/app_status.R
@@ -309,9 +309,9 @@ app_status_app_sha <- function(
   dir
 ) {
   dir <- normalizePath(dir)
-
+  owd <- setwd(dir)
+  on.exit(setwd(owd), add = TRUE)
   run_system_cmd(
-    "cd '", dir, "' && ",
     "git rev-parse --short HEAD"
   )
 }


### PR DESCRIPTION
Fixes `Error in system: 'cd' not found` on Windows