### PR TITLE
Reinstall parent package if GitHub Remotes are installed from CRAN

### DIFF
--- a/R/deps_exact.R
+++ b/R/deps_exact.R
@@ -96,7 +96,7 @@ install_exact_shinycoreci_deps <- function(dir = "apps", try_again = TRUE) {
           return()
         }
         # get the remote of the currently installed github package
-        remote <- subset(scci_dev_deps, package == pkg)$remote[[1]]
+        remote <- scci_dev_deps$remote[scci_dev_deps$package == pkg][[1]]
         # reinstall it to bring in all missing dependencies
         remotes::install_github(repo_from_remote(remote), force = TRUE, upgrade = TRUE)
       }
@@ -174,7 +174,7 @@ remote_deps_recursive <- function(package_name) {
 
 repo_from_remote <- function(remote_obj) {
   if (!inherits(remote_obj, "github_remote")) {
-    str(remote_obj)
+    utils::str(remote_obj)
     stop("not a remote!")
   }
   paste0(

--- a/R/deps_exact.R
+++ b/R/deps_exact.R
@@ -27,8 +27,19 @@ install_exact_shinycoreci_deps <- function(dir = "apps", try_again = TRUE) {
 
   # all remotes based from shinycoreci
   message("Gathering recursive remotes...", appendLF = FALSE)
-  scci_remotes <- remote_deps_recursive("shinycoreci")
-  message(" OK")
+  scci_remotes_all <- tryCatch({
+    ans <- remote_deps_recursive("shinycoreci")
+    message(" OK")
+    ans
+  }, error = function(e) {
+    # a shinycoreci dependency could not be found. Reinstall shinycoreci
+    message("")
+    message("Reinstalling shinycoreci. Not all dependencies found")
+    installed_something <<- TRUE
+    remotes::install_github(repo_from_remote(shinycoreci_info$remote[[1]]), upgrade = TRUE, force = TRUE)
+    remote_deps_recursive("shinycoreci")
+  })
+  scci_remotes <- unique(unname(unlist(scci_remotes_all)))
 
   message("Gathering dependency information...", appendLF = FALSE)
   scci_dev_deps <- app_deps(dir)
@@ -39,12 +50,11 @@ install_exact_shinycoreci_deps <- function(dir = "apps", try_again = TRUE) {
   should_be_github_only <- scci_remotes
 
   # check cran pkgs
-  message("Checking CRAN packages...", appendLF = FALSE)
+  message("Checking all non-Remote packages are CRAN packages...", appendLF = FALSE)
   cran_info <- scci_dev_deps[scci_dev_deps$package %in% should_be_cran_only, ]
   # get packages that are currently not cran sources or are behind in version
   should_install_cran <- (!cran_info$is_cran) | (cran_info$diff < 0)
-  if (any(should_install_cran)) {
-
+  if (any(!cran_info$is_cran)) {
     installed_something <- TRUE
     to_install <- cran_info$package[should_install_cran]
     message("") # close off line
@@ -58,7 +68,7 @@ install_exact_shinycoreci_deps <- function(dir = "apps", try_again = TRUE) {
             utils::remove.packages(pkg_to_install)
           }, silent = TRUE)
         })
-        # install all the things from CRAN
+        # force install all the things from CRAN
         utils::install.packages(to_install_, dependencies = TRUE)
       },
       list(to_install_ = to_install),
@@ -68,15 +78,41 @@ install_exact_shinycoreci_deps <- function(dir = "apps", try_again = TRUE) {
     message(" OK")
   }
 
-  message("Checking GitHub packages...", appendLF = FALSE)
+  message("Checking all Remotes are installed from GitHub...", appendLF = FALSE)
   remotes_info <- scci_dev_deps[scci_dev_deps$package %in% should_be_github_only, ]
   # check if packages are installed from github or are behind
-  should_install_github <- remotes_info$is_cran | (remotes_info$diff < 0)
-  if (any(should_install_github)) {
+  if (any(remotes_info$is_cran)) {
     message("") # close off line
     installed_something <- TRUE
-    print(remotes_info)
-    remotes__update_package_deps(remotes_info, upgrade = TRUE, dependencies = TRUE)
+    message("Re-installing some packages as these Remotes were not installed from GitHub")
+    print(tibble::as_tibble(remotes_info[remotes_info$is_cran, ]))
+
+    currently_cran_needs_github_pkgs <- remotes_info$package[remotes_info$is_cran]
+    mapply(
+      names(scci_remotes_all),
+      scci_remotes_all,
+      FUN = function(pkg, github_deps) {
+        if (!any(currently_cran_needs_github_pkgs %in% github_deps)) {
+          return()
+        }
+        # get the remote of the currently installed github package
+        remote <- subset(scci_dev_deps, package == pkg)$remote[[1]]
+        # reinstall it to bring in all missing dependencies
+        remotes::install_github(repo_from_remote(remote), force = TRUE, upgrade = TRUE)
+      }
+    )
+  } else {
+    message(" OK")
+  }
+
+  message("Checking GitHub packages are up to date...", appendLF = FALSE)
+  should_update_github <- (remotes_info$diff < 0) & (!remotes_info$is_cran)
+  if (any(should_update_github)) {
+    message("") # close off line
+    installed_something <- TRUE
+    message("Updating GitHub packages:")
+    print(tibble::as_tibble(remotes_info[should_update_github, ]))
+    remotes__update_package_deps(remotes_info[should_update_github, ], upgrade = TRUE, dependencies = TRUE)
   } else {
     message(" OK")
   }
@@ -109,20 +145,43 @@ install_exact_shinycoreci_deps <- function(dir = "apps", try_again = TRUE) {
 ## , then the parent will be installed due to a bad remote value (which also installs the dep package)
 remote_deps_recursive <- function(package_name) {
 
-  has_calculated <- list()
+  ret <- list()
 
   remote_deps_recursive_ <- function(pkg_name) {
-    if (isTRUE(has_calculated[[pkg_name]])) {
-      return(NULL)
+    if (!is.null(ret[[pkg_name]])) {
+      return(ret[[pkg_name]])
     }
     rem_deps <- remotes__remote_deps(
       remotes__load_pkg_description(system.file(package = pkg_name))
     )
-    unique(c(
-      rem_deps$package,
-      unlist(lapply(rem_deps$package, remote_deps_recursive_))
-    ))
+
+    # store
+    ret[[pkg_name]] <<- rem_deps$package
+
+    # call on those remotes
+    unlist(lapply(rem_deps$package, remote_deps_recursive_))
+
+    # return
+    ret[[pkg_name]]
   }
 
+
   remote_deps_recursive_(package_name)
+
+  ret
+}
+
+
+repo_from_remote <- function(remote_obj) {
+  if (!inherits(remote_obj, "github_remote")) {
+    str(remote_obj)
+    stop("not a remote!")
+  }
+  paste0(
+    remote_obj$username,
+    "/",
+    remote_obj$repo,
+    "@",
+    remote_obj$branch %||% "master"
+  )
 }


### PR DESCRIPTION
Fixes situation where

```
github:shinycoreci -> github:flexdashboard
github:shinycoreci -> cran:rmarkdown
github:flexdashboard -> github:rmarkdown
```