### PR TITLE
Use git pull, not git fetch, to make sure the disk is the latest version

### DIFF
--- a/R/app_status.R
+++ b/R/app_status.R
@@ -342,7 +342,7 @@ app_status_validate_app_branch <- function(dir) {
     }
   }
 
-  run_system_cmd("git fetch")
+  run_system_cmd("git pull")
   # make sure there is some character value to test
   is_up_to_date <- paste0(run_system_cmd("git status -s -u no"), "")
   if (nchar(is_up_to_date) > 0) {


### PR DESCRIPTION
`git fetch` will say "you are behind by 5 commits". This is bad as I don't want the disk to be behind.  It should be updated