### PR TITLE
Use `pkgdepends` to find the full install tree

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     renv,
     rstudioapi (>= 0.11)
 Suggests:
+    pkgdepends,
     Rcpp (>= 1.0.4.6),
     httr,
     tibble,
@@ -56,6 +57,7 @@ Suggests:
     tidyr,
     gt
 Remotes:
+  r-lib/pkgdepends,
   r-lib/fastmap,
   r-lib/later,
   r-lib/cachem,

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ These `Remotes` will be installed to make sure the latest package development is
   - [r-lib/cachem](http://github.com/r-lib/cachem)
   - [r-lib/fastmap](http://github.com/r-lib/fastmap)
   - [r-lib/later](http://github.com/r-lib/later)
+  - [r-lib/pkgdepends](http://github.com/r-lib/pkgdepends)
   - [rstudio/bslib@rc-v0.2.4](http://github.com/rstudio/bslib)
   - [rstudio/crosstalk](http://github.com/rstudio/crosstalk)
   - [rstudio/flexdashboard](http://github.com/rstudio/flexdashboard)


### PR DESCRIPTION
Helps for older R versions trying to update pkgs like `rlang`.