### PR TITLE
Add support for asking for branches and apps before fixing

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 \.sublime-project$
 ^.*\.Rproj$
 ^README\.Rmd$
+^shinyverse.png$

--- a/R/fix_all_gha_branches.R
+++ b/R/fix_all_gha_branches.R
@@ -143,7 +143,7 @@ fix_all_gha_branches <- function(
           app_info_dt_for_combo$os, "-", app_info_dt_for_combo$r_version,
           collapse = ", "
         )
-        cat("* ", app_testname, " : ", app_testname, " ; ", os_r_version, "\n", sep = "")
+        cat("* ", app_testname, " ; ", os_r_version, "\n", sep = "")
       }
     )
   }

--- a/man/fix_all_gha_branches.Rd
+++ b/man/fix_all_gha_branches.Rd
@@ -8,9 +8,10 @@ fix_all_gha_branches(
   dir = "apps",
   sha = git_sha(dir),
   ...,
-  merge = FALSE,
-  commit = merge,
-  ask = interactive(),
+  save_results = NULL,
+  ask_apps = TRUE,
+  ask_branches = FALSE,
+  ask_if_not_master = TRUE,
   repo_dir = file.path(dir, "..")
 )
 }
@@ -21,11 +22,11 @@ fix_all_gha_branches(
 
 \item{...}{Extra arguments passed to \code{shinytest::viewTestDiff}}
 
-\item{merge}{Logical which merges all branches after viewing test results}
+\item{save_results}{Logical which commits and merges all branches after viewing test results}
 
-\item{commit}{Logical which determines if shinytest results should be committed}
+\item{ask_apps, ask_branches}{Logical which allows for particular apps branches to be inspected}
 
-\item{ask}{Logical which allows for particular branches to be inspected}
+\item{ask_if_not_master}{Logical which will check if \code{master} is the base branch}
 
 \item{repo_dir}{Root repo folder path}
 }


### PR DESCRIPTION
Fixes https://github.com/rstudio/shinycoreci/issues/61

* Rename `merge` / `commit` to `save_results = NULL` (which asks by default)
* If `save_result = FALSE`, all app folder changes will be reset before moving on
* Split `ask` into `ask_apps = TRUE` and `ask_branches = FALSE`
* Add `ask_if_not_master` branch support
* Use an internal data.frame for easier ordering / subsetting