### PR TITLE
Add in shinyvalidate remote pkg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -56,6 +56,7 @@ Suggests:
     english,
     dplyr,
     tidyr,
+    shinyvalidate,
     gt
 Remotes:
   r-lib/pkgdepends,
@@ -76,6 +77,7 @@ Remotes:
   rstudio/shiny,
   rstudio/shinythemes,
   rstudio/shinytest,
+  rstudio/shinyvalidate,
   rstudio/pool,
   rstudio/reactlog,
   rstudio/shinymeta

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,6 +31,7 @@ rm_files <- function(filenames) {
   plotly::plot_ly
   leaflet::leaflet
   leaflet.providers::get_providers
+  shinyvalidate::compose_rules
   crosstalk::crosstalkLibs
   flexdashboard::flex_dashboard
   shinymeta::formatCode

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ These `Remotes` will be installed to make sure the latest package development is
   - [rstudio/shinymeta](http://github.com/rstudio/shinymeta)
   - [rstudio/shinytest](http://github.com/rstudio/shinytest)
   - [rstudio/shinythemes](http://github.com/rstudio/shinythemes)
+  - [rstudio/shinyvalidate](http://github.com/rstudio/shinyvalidate)
   - [rstudio/thematic](http://github.com/rstudio/thematic)
   - [rstudio/websocket](http://github.com/rstudio/websocket)
   - [schloerke/shinyjster](http://github.com/schloerke/shinyjster)


### PR DESCRIPTION
Should resolve error: https://github.com/rstudio/shinycoreci-apps/runs/2181707322?check_suite_focus=true

```
2021-03-24T07:12:23.2879560Z 211-sv-custom-inputs [============================] 1/1 eta: 0s elapsed: 0s
2021-03-24T07:12:23.2880460Z 
2021-03-24T07:12:23.5942000Z Preparing to deploy application...DONE
2021-03-24T07:12:25.1419120Z Uploading bundle for application: 3787325...Error : Unable to retrieve package records for the following packages:
2021-03-24T07:12:25.1421500Z - 'shinyvalidate'
2021-03-24T07:12:25.1422700Z In addition: Warning message:
2021-03-24T07:12:25.1423570Z In FUN(X[[i]], ...) :
2021-03-24T07:12:25.1425130Z   Package 'shinyvalidate' not available in repository or locally
2021-03-24T07:12:25.1426100Z 
2021-03-24T07:12:25.1427320Z Warning message:
2021-03-24T07:12:25.1428240Z In FUN(X[[i]], ...) :
2021-03-24T07:12:25.1429980Z   Package 'shinyvalidate' not available in repository or locally
2021-03-24T07:12:25.1430680Z 
2021-03-24T07:12:25.1627810Z Retrying to deploy problem apps.  Calling:
2021-03-24T07:12:25.1630690Z deploy_apps(dir = "apps", apps = "211-sv-custom-inputs", account = "testing-apps", server = "shinyapps.io", cores = 1, update_pkgs = "none", retry = 0)
```