### PR TITLE
Followup updates `view_test_results()`

### DIFF
--- a/inst/view_test_diff/app.R
+++ b/inst/view_test_diff/app.R
@@ -76,11 +76,11 @@ ui <- fluidPage(
   tags$head(tags$style(HTML("
   .dataTables_filter {display: none};
   .result_app {padding: 0.5em; border-collapse: collapse;}
-  .result_pass {background-color: #4b9058 !important;}
-  .result_fail {background-color: #af423c !important;}
-  .result_can_not_install {background-color: #4b6090 !important;}
-  .result_did_not_return {background-color: #a3a3a3 !important;}
-  .result_did_not_execute {background-color: #323232 !important;}
+  .result_pass {background-color: #009469 !important;} /* green */
+  .result_fail {background-color: #d95515 !important;} /* red */
+  .result_can_not_install {background-color: #0066a7 !important;} /* blue */
+  .result_did_not_return {background-color: #a3a3a3 !important;} /* white */
+  .result_did_not_execute {background-color: #323232 !important;} /* black */
   .result_day td {border: 1px dotted grey;}
   .result_app > tbody > tr > td { }
   .result_day td {

--- a/inst/view_test_diff/app.R
+++ b/inst/view_test_diff/app.R
@@ -185,6 +185,12 @@ server <- function(input, output, session) {
       d <- arrange(d, desc(fail))
     }
 
+    for (nme in c("can_not_install", "did_not_return_result", "fail", "pass")) {
+      if (!rlang::has_name(d, nme)) {
+        d[[nme]] <- 0
+      }
+    }
+
     d <- d %>%
       complete(
         app_name, os, r_version, date,

--- a/inst/view_test_diff/app.R
+++ b/inst/view_test_diff/app.R
@@ -82,8 +82,20 @@ ui <- fluidPage(
   .result_did_not_return {background-color: #a3a3a3 !important;}
   .result_did_not_execute {background-color: #323232 !important;}
   .result_day td {border: 1px dotted grey;}
-  .result_app > tbody > tr > td { padding: 0px !important; padding-right: 2px !important;}
-  .result_day td { padding: 0.5rem !important;}
+  .result_app > tbody > tr > td { }
+  .result_day td {
+    padding: 0.5rem !important;
+    border-radius: 50%;
+    /* No border */
+  }
+  .result_day {
+    border-spacing: 1px;
+    border-collapse: separate;
+  }
+  .result_app > tbody > tr > td {
+      padding: 0px !important;
+      padding-right: 6px !important;
+  }
 "))),
   div(
     style = "display:flex; flex-direction: column; align-items: flex-start",

--- a/inst/view_test_diff/app.R
+++ b/inst/view_test_diff/app.R
@@ -26,7 +26,7 @@ strextract <- function(str, pattern) {
 }
 
 
-test_results <- function(files) {
+test_results <- memoise::memoise(function(files) {
   results <- lapply(files, test_results_import)
   bind_rows(results) %>%
     tibble::as_tibble() %>%
@@ -41,7 +41,7 @@ test_results <- function(files) {
       sha = paste0(branch_name, "@", sha)
     ) %>%
     arrange(desc(time))
-}
+})
 
 test_results_import <- function(f) {
   json <- jsonlite::fromJSON(f)

--- a/inst/view_test_diff/app.R
+++ b/inst/view_test_diff/app.R
@@ -163,7 +163,6 @@ server <- function(input, output, session) {
     platforms(platforms_)
   })
   observeEvent(platforms(), {
-    str(platforms())
     updateSelectInput(session, "platform", choices = platforms())
   })
 

--- a/inst/view_test_diff/app.R
+++ b/inst/view_test_diff/app.R
@@ -96,6 +96,14 @@ ui <- fluidPage(
       padding: 0px !important;
       padding-right: 6px !important;
   }
+
+  /* Reduce title height */
+  .form-group {
+    margin-bottom: 0 !important;
+  }
+  .selectize-control {
+    margin-bottom: 0 !important;
+  }
 "))),
   div(
     style = "display:flex; flex-direction: column; align-items: flex-start",
@@ -344,7 +352,7 @@ server <- function(input, output, session) {
         autoWidth = TRUE,
         columnDefs = list(list(width = '30px', targets = c(2,3,4,5,6))),
 
-        paging = FALSE, #searching = FALSE,
+        info = FALSE, paging = FALSE, #searching = FALSE,
         scrollY = "80vh",
         order = list(list(2, 'desc')),
 


### PR DESCRIPTION
Related: #68 

* Circles for results
* Okabe ito colors
* Do not have platform be dynamic. Only append platforms
* Safeguard spread operation

Updated colors and through colorblind simulation

![Screen Shot 2021-06-28 at 5 20 00 PM](https://user-images.githubusercontent.com/93231/123705742-54a68e80-d835-11eb-98c0-9309fdfa0d27.png)
![Screen Shot 2021-06-28 at 5 20 21 PM](https://user-images.githubusercontent.com/93231/123705746-553f2500-d835-11eb-80ab-8baa242a5ad0.png)
