### PR TITLE
Temporarily Do not test `shinyjster` mac firefox tests

### DIFF
--- a/R/test_app.R
+++ b/R/test_app.R
@@ -51,7 +51,7 @@ test_shinyjster_app <- function(
   
   # Temp workaround while mac firefox apps don't complete in time
   if (browser_name_val %in% "firefox") {
-    if (platform() == "mac")) {
+    if (platform() == "mac") {
       # return NULL to signify that no test was done
       return(NULL)
     }

--- a/R/test_app.R
+++ b/R/test_app.R
@@ -48,6 +48,14 @@ test_shinyjster_app <- function(
       return(NULL)
     }
   }
+  
+  # Temp workaround while mac firefox apps don't complete in time
+  if (browser_name_val %in% "firefox") {
+    if (platform() == "mac")) {
+      # return NULL to signify that no test was done
+      return(NULL)
+    }
+  }
 
   shinyjster::test_jster(apps = apps, browsers = browser_func, type = "lapply")
 }


### PR DESCRIPTION
For 10+ days, mac tests have not been able to complete. No known change was made to cause this.

For now, disabling the mac firefox tests.

cc @MadhulikaTanuboddi 

----------------

Ex output: https://github.com/rstudio/shinycoreci-apps/runs/3723131787?check_suite_focus=true#step:32:1407

```
[89/377; 2h; 6h] 123-async-renderprint ~ shinyjster-firefox.R
Loading required package: shiny
shinyjster - starting app: 123-async-renderprint
Warning: Warning: Strategy 'multiprocess' is deprecated in future (>= 1.20.0). Instead, explicitly specify either 'multisession' or 'multicore'. In the current R session, 'multiprocess' equals 'multicore'.

Listening on http://127.0.0.1:45939
Running java -jar \
  /Users/runner/work/_temp/Library/shinyjster/selenium/selenium.jar firefox \
  1200x1200 'http://127.0.0.1:45939/?shinyjster=1' 120 -headless
pxjava - Exception in thread "main" java.lang.reflect.InvocationTargetException
pxjava - 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
pxjava - 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
pxjava - 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
pxjava - 	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
pxjava - 	at com.rstudio.seleniumRunner.MainKt.main(Main.kt:73)
pxjava - Caused by: org.openqa.selenium.WebDriverException: java.net.ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:30113
pxjava - Build info: version: 'unknown', revision: 'unknown', time: 'unknown'
pxjava - System info: host: 'Mac-1632765763059.local', ip: '10.79.1.179', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.15.7', java.version: '1.8.0_302'
pxjava - Driver info: driver.version: FirefoxDriver
pxjava - 	at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:92)
pxjava - 	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:552)
pxjava - 	at org.openqa.selenium.remote.RemoteWebDriver.startSession(RemoteWebDriver.java:213)
pxjava - 	at org.openqa.selenium.remote.RemoteWebDriver.<init>(RemoteWebDriver.java:131)
pxjava - 	at org.openqa.selenium.firefox.FirefoxDriver.<init>(FirefoxDriver.java:147)
pxjava - 	... 5 more
pxjava - Caused by: java.net.ConnectException: Failed to connect to localhost/0:0:0:0:0:0:0:1:30113
pxjava - 	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:247)
pxjava - 	at okhttp3.internal.connection.RealConnection.connect(RealConnection.java:165)
pxjava - 	at okhttp3.internal.connection.StreamAllocation.findConnection(StreamAllocation.java:257)
pxjava - 	at okhttp3.internal.connection.StreamAllocation.findHealthyConnection(StreamAllocation.java:135)
pxjava - 	at okhttp3.internal.connection.StreamAllocation.newStream(StreamAllocation.java:114)
pxjava - 	at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.java:42)
pxjava - 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
pxjava - 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
pxjava - 	at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.java:93)
pxjava - 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
pxjava - 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
pxjava - 	at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.java:93)
pxjava - 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
pxjava - 	at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.java:126)
pxjava - 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:147)
pxjava - 	at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.java:121)
pxjava - 	at okhttp3.RealCall.getResponseWithInterceptorChain(RealCall.java:200)
pxjava - 	at okhttp3.RealCall.execute(RealCall.java:77)
pxjava - 	at org.openqa.selenium.remote.internal.OkHttpClient.execute(OkHttpClient.java:103)
pxjava - 	at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:105)
pxjava - 	at org.openqa.selenium.remote.ProtocolHandshake.createSession(ProtocolHandshake.java:74)
pxjava - 	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:136)
pxjava - 	at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:83)
pxjava - 	... 9 more
pxjava - Caused by: java.net.ConnectException: Connection refused (Connection refused)
pxjava - 	at java.net.PlainSocketImpl.socketConnect(Native Method)
pxjava - 	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
pxjava - 	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
pxjava - 	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
pxjava - 	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
pxjava - 	at java.net.Socket.connect(Socket.java:607)
pxjava - 	at okhttp3.internal.platform.Platform.connectSocket(Platform.java:129)
pxjava - 	at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.java:245)
pxjava - 	... 31 more
pxjava - Selenium Processx closed
```