### PR TITLE
Minor updates to rituals workflow

### DIFF
--- a/.github/workflows/call-rituals.yaml
+++ b/.github/workflows/call-rituals.yaml
@@ -132,7 +132,7 @@ jobs:
           if [ -n "`git cherry origin/HEAD`" ]; then
             echo "Un-pushed commits:"
             git cherry -v origin/HEAD
-            echo "\nShould not push to HEAD branch. Please make a PR to have changes be collected. Exiting"
+            echo "::error:: Should not push to HEAD branch. Please make a PR to have changes be collected. Exiting"
             exit 1
           fi
 


### PR DESCRIPTION
- Changes from `urlchecker` should be updates to tracked files only, so use `git add -u`
- Sets a [GHA error message](https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#setting-an-error-message) if unpushed commits are detected