### PR TITLE
Change from fixed time sleep to `$wait_for_idle()` where possible

### DIFF
--- a/inst/apps/012-datatables/tests/testthat/test-mytest.R
+++ b/inst/apps/012-datatables/tests/testthat/test-mytest.R
@@ -9,7 +9,7 @@ test_that("Migrated shinytest test: mytest.R", {
     width = 1200
   )
 
-  Sys.sleep(1)
+  app$wait_for_idle()
   # Input 'mytable1_rows_current' was set, but doesn't have an input binding.
   # Input 'mytable1_rows_all' was set, but doesn't have an input binding.
   app$expect_values()
@@ -22,7 +22,7 @@ test_that("Migrated shinytest test: mytest.R", {
     "price", "x", "y", "z"))
   # Input 'mytable1_rows_current' was set, but doesn't have an input binding.
   # Input 'mytable1_rows_all' was set, but doesn't have an input binding.
-  Sys.sleep(1)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
   app$set_inputs(show_vars = c("color", "clarity", "price", "y",
@@ -39,11 +39,11 @@ test_that("Migrated shinytest test: mytest.R", {
   # Input 'mytable1_rows_current' was set, but doesn't have an input binding.
   # Input 'mytable1_rows_all' was set, but doesn't have an input binding.
   app$set_inputs(show_vars = "z")
-  Sys.sleep(1)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
   app$set_inputs(dataset = "mtcars")
-  Sys.sleep(1)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/014-onflushed/tests/testthat/test-mytest.R
+++ b/inst/apps/014-onflushed/tests/testthat/test-mytest.R
@@ -5,7 +5,7 @@ test_that("Migrated shinytest test: mytest.R", {
     seed = 100, shiny_args = list(display.mode = "normal"))
   app$expect_values()
   app$expect_screenshot()
-  Sys.sleep(2)
+  Sys.sleep(2) # wait for flush
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/019-mathjax/tests/testthat/test-mytest.R
+++ b/inst/apps/019-mathjax/tests/testthat/test-mytest.R
@@ -4,11 +4,12 @@ test_that("Migrated shinytest test: mytest.R", {
   app <- AppDriver$new(variant = shinytest2::platform_variant(),
     load_timeout = 15000, seed = 100, shiny_args = list(display.mode = "normal"))
 
-  Sys.sleep(3)
+  Sys.sleep(3) # wait for mathjax to process
   app$expect_values()
   app$expect_screenshot()
+
   app$set_inputs(ex5_visible = TRUE)
-  Sys.sleep(2)
+  Sys.sleep(2) # wait for mathjax to process
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/020-knit-html/tests/testthat/test-mytest.R
+++ b/inst/apps/020-knit-html/tests/testthat/test-mytest.R
@@ -4,11 +4,12 @@ test_that("Migrated shinytest test: mytest.R", {
   app <- AppDriver$new(variant = shinytest2::platform_variant(),
     seed = 100, shiny_args = list(display.mode = "normal"))
 
-  Sys.sleep(3)
+  Sys.sleep(3) # wait for mathjax to process
   app$expect_values()
   app$expect_screenshot()
+
   app$set_inputs(x = "hp")
-  Sys.sleep(2)
+  Sys.sleep(2) # wait for mathjax to process
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/026-shiny-inline/tests/testthat/test-mytest.R
+++ b/inst/apps/026-shiny-inline/tests/testthat/test-mytest.R
@@ -1,14 +1,17 @@
 library(shinytest2)
 
 test_that("Migrated shinytest test: mytest.R", {
-  app <- AppDriver$new("../../index.Rmd", variant = shinytest2::platform_variant(),
+  app <- AppDriver$new(variant = shinytest2::platform_variant(),
     seed = 8296, shiny_args = list(display.mode = "normal"))
-  Sys.sleep(4)
+
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
+
   app$set_inputs(asp = 0.3)
   app$expect_values()
   app$expect_screenshot()
+
   app$set_inputs(asp = 0.02)
   app$set_inputs(asp = 0.3)
   app$set_inputs(asp = 0.02)

--- a/inst/apps/054-nvd3-line-chart-output/tests/testthat/test-mytest.R
+++ b/inst/apps/054-nvd3-line-chart-output/tests/testthat/test-mytest.R
@@ -4,18 +4,18 @@ test_that("Migrated shinytest test: mytest.R", {
   app <- AppDriver$new(variant = shinytest2::platform_variant(),
     seed = 100, shiny_args = list(display.mode = "normal"))
 
-  Sys.sleep(2)
+  Sys.sleep(2) # wait for widget
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(sineAmplitude = -1.5)
-  Sys.sleep(2)
+  Sys.sleep(2) # wait for widget
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(sineAmplitude = -0.1)
   app$set_inputs(sinePhase = 100)
-  Sys.sleep(2)
+  Sys.sleep(2) # wait for widget
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/082-word-cloud/tests/testthat/test-mytest.R
+++ b/inst/apps/082-word-cloud/tests/testthat/test-mytest.R
@@ -4,17 +4,20 @@ test_that("Migrated shinytest test: mytest.R", {
   app <- AppDriver$new(variant = shinytest2::platform_variant(),
     seed = 100, shiny_args = list(display.mode = "normal"))
 
-  Sys.sleep(1)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
+
   app$set_inputs(freq = 35)
   app$set_inputs(max = 250)
   app$set_inputs(selection = "merchant")
   app$expect_values()
   app$expect_screenshot()
+
   app$set_inputs(selection = "romeo")
   app$expect_values()
   app$expect_screenshot()
+
   app$set_inputs(update = "click")
   app$set_inputs(freq = 10)
   app$expect_values()

--- a/inst/apps/114-modal-dialog/tests/testthat/test-mytest.R
+++ b/inst/apps/114-modal-dialog/tests/testthat/test-mytest.R
@@ -5,7 +5,7 @@ test_that("Migrated shinytest test: mytest.R", {
     seed = 100, shiny_args = list(display.mode = "normal"))
 
   app$set_inputs(show = "click")
-  Sys.sleep(1)
+  Sys.sleep(1) # Wait for modal to appear
   app$expect_values()
   app$expect_screenshot()
 

--- a/inst/apps/117-shinythemes/tests/testthat/test-mytest.R
+++ b/inst/apps/117-shinythemes/tests/testthat/test-mytest.R
@@ -6,16 +6,19 @@ test_that("Migrated shinytest test: mytest.R", {
 
   app$expect_values()
   app$expect_screenshot()
+
   app$set_inputs(`shinytheme-selector` = "lumen")
-  Sys.sleep(2)
+  Sys.sleep(2) # wait for css
   app$expect_values()
   app$expect_screenshot()
+
   app$set_inputs(`shinytheme-selector` = "spacelab")
-  Sys.sleep(2)
+  Sys.sleep(2) # wait for css
   app$expect_values()
   app$expect_screenshot()
+
   app$set_inputs(`shinytheme-selector` = "yeti")
-  Sys.sleep(2)
+  Sys.sleep(2) # wait for css
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/118-highcharter-births/tests/testthat/test-mytest.R
+++ b/inst/apps/118-highcharter-births/tests/testthat/test-mytest.R
@@ -4,14 +4,15 @@ test_that("Migrated shinytest test: mytest.R", {
   app <- AppDriver$new(variant = shinytest2::platform_variant(),
     seed = 100, shiny_args = list(display.mode = "normal"))
 
-  Sys.sleep(2)
+  Sys.sleep(2) # wait for widget
   app$expect_values()
   app$expect_screenshot()
+
   app$set_inputs(year = c(1994, 2005))
   app$set_inputs(year = c(1997, 2005))
   app$set_inputs(plot_type = "column")
   app$set_inputs(theme = "fivethirtyeight")
-  Sys.sleep(2)
+  Sys.sleep(2) # wait for widget / css
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/119-namespaced-conditionalpanel-demo/tests/testthat/test-mytest.R
+++ b/inst/apps/119-namespaced-conditionalpanel-demo/tests/testthat/test-mytest.R
@@ -4,15 +4,17 @@ test_that("Migrated shinytest test: mytest.R", {
   app <- AppDriver$new(variant = shinytest2::platform_variant(),
     seed = 100, shiny_args = list(display.mode = "normal"))
 
-  Sys.sleep(1)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
+
   app$set_inputs(`plot1-n` = 180)
-  Sys.sleep(0.5)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
+
   app$set_inputs(`plot2-n` = 190)
-  Sys.sleep(0.5)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/122-async-outputs/tests/testthat/test-mytest.R
+++ b/inst/apps/122-async-outputs/tests/testthat/test-mytest.R
@@ -4,7 +4,7 @@ test_that("Migrated shinytest test: mytest.R", {
   app <- AppDriver$new(variant = shinytest2::platform_variant(),
     load_timeout = 15000, seed = 100, shiny_args = list(display.mode = "normal"))
 
-  Sys.sleep(2)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/123-async-renderprint/tests/testthat/test-mytest.R
+++ b/inst/apps/123-async-renderprint/tests/testthat/test-mytest.R
@@ -4,7 +4,7 @@ test_that("Migrated shinytest test: mytest.R", {
   app <- AppDriver$new(variant = shinytest2::platform_variant(),
     load_timeout = 10000, seed = 100, shiny_args = list(display.mode = "normal"))
 
-  Sys.sleep(2)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/125-async-req/tests/testthat/test-mytest.R
+++ b/inst/apps/125-async-req/tests/testthat/test-mytest.R
@@ -3,7 +3,7 @@ library(shinytest2)
 test_that("Migrated shinytest test: mytest.R", {
   app <- AppDriver$new(variant = shinytest2::platform_variant())
 
-  Sys.sleep(2)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
   app$set_inputs(boom = "click")

--- a/inst/apps/135-bookmark-uioutput/tests/testthat/test-mytest.R
+++ b/inst/apps/135-bookmark-uioutput/tests/testthat/test-mytest.R
@@ -3,18 +3,18 @@ library(shinytest2)
 test_that("Migrated shinytest test: mytest.R", {
   app <- AppDriver$new(variant = shinytest2::platform_variant())
 
-  Sys.sleep(1)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(._bookmark_ = "click")
-  Sys.sleep(1)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(x = 10)
   app$set_inputs(._bookmark_ = "click")
-  Sys.sleep(1)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
 

--- a/inst/apps/137-plot-cache-key/app.R
+++ b/inst/apps/137-plot-cache-key/app.R
@@ -24,7 +24,7 @@ server <- function(input, output, session) {
 
   output$plot <- renderCachedPlot(
     {
-      Sys.sleep(2)     # Add an artificial delay
+      Sys.sleep(2) # Add an artificial delay
       d <- dataset()
       rownums <- seq_len(input$n)
       plot(d$x[rownums], d$y[rownums], xlim = range(d$x), ylim = range(d$y))

--- a/inst/apps/142-reactive-timer/app.R
+++ b/inst/apps/142-reactive-timer/app.R
@@ -138,7 +138,7 @@ server <- function(input, output, session) {
   })
 
   observeEvent(input$busy_sync, {
-    Sys.sleep(5)
+    Sys.sleep(5) # Add an artificial delay
   })
 
   observeEvent(input$busy_async, {

--- a/inst/apps/149-onRender/tests/testthat/test-mytest.R
+++ b/inst/apps/149-onRender/tests/testthat/test-mytest.R
@@ -6,7 +6,7 @@ test_that("Migrated shinytest test: mytest.R", {
   app <- AppDriver$new(variant = shinytest2::platform_variant())
 
   app$wait_for_value(output = "p3")
-  Sys.sleep(2)
+  Sys.sleep(2) # wait for widgets
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/150-networkD3-sankey/tests/testthat/test-mytest.R
+++ b/inst/apps/150-networkD3-sankey/tests/testthat/test-mytest.R
@@ -13,7 +13,7 @@ test_that("Migrated shinytest test: mytest.R", {
   app$expect_values()
   app$expect_screenshot()
   app$set_inputs(._bookmark_ = "click")
-  Sys.sleep(1)
+  Sys.sleep(1) # wait for modal
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/151-reactr-input/tests/testthat/test-mytest.R
+++ b/inst/apps/151-reactr-input/tests/testthat/test-mytest.R
@@ -16,7 +16,7 @@ test_that("Migrated shinytest test: mytest.R", {
   app$expect_values()
   app$expect_screenshot()
   app$set_inputs(._bookmark_ = "click")
-  Sys.sleep(1)
+  Sys.sleep(1) # wait for modal
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/156-subapps/tests/testthat/test-mytest.R
+++ b/inst/apps/156-subapps/tests/testthat/test-mytest.R
@@ -4,7 +4,7 @@ test_that("Migrated shinytest test: mytest.R", {
   app <- AppDriver$new("../../index.Rmd", variant = shinytest2::platform_variant(),
     seed = 91546)
 
-  Sys.sleep(8)
+  Sys.sleep(8) # wait for apps to load
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/190-reactlog-module-ex1/tests/testthat/test-mytest.R
+++ b/inst/apps/190-reactlog-module-ex1/tests/testthat/test-mytest.R
@@ -5,12 +5,12 @@ test_that("Migrated shinytest test: mytest.R", {
     seed = 54322)
 
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 
@@ -18,12 +18,12 @@ test_that("Migrated shinytest test: mytest.R", {
   app$set_inputs(obs = 8)
 
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/191-reactlog-pythagoras/tests/testthat/test-mytest.R
+++ b/inst/apps/191-reactlog-pythagoras/tests/testthat/test-mytest.R
@@ -5,14 +5,14 @@ test_that("Migrated shinytest test: mytest.R", {
     seed = 54322)
 
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(a = 5, b = 12)
 
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/192-reactlog-hello/tests/testthat/test-mytest.R
+++ b/inst/apps/192-reactlog-hello/tests/testthat/test-mytest.R
@@ -5,20 +5,20 @@ test_that("Migrated shinytest test: mytest.R", {
     seed = 100, shiny_args = list(display.mode = "normal"))
 
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(bins = 8)
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(bins = 5)
   app$set_inputs(bins = 22)
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/193-reactlog-dynamic-ui/tests/testthat/test-mytest.R
+++ b/inst/apps/193-reactlog-dynamic-ui/tests/testthat/test-mytest.R
@@ -25,13 +25,13 @@ test_that("Migrated shinytest test: mytest.R", {
 
 
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(dynamic = 14)
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 
@@ -68,7 +68,7 @@ test_that("Migrated shinytest test: mytest.R", {
   app$set_inputs(dynamic = c("2020-01-08", "2020-01-31"))
 
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/194-plot-cache-key/app.R
+++ b/inst/apps/194-plot-cache-key/app.R
@@ -30,7 +30,7 @@ server <- function(input, output, session) {
 
   output$plot <- renderCachedPlot(
     {
-      Sys.sleep(2)     # Add an artificial delay
+      Sys.sleep(2) # Add an artificial delay
       d <- dataset()
       rownums <- seq_len(input$n)
       plot(d$x[rownums], d$y[rownums], xlim = range(d$x), ylim = range(d$y))

--- a/inst/apps/194-plot-cache-key/tests/testthat/test-mytest.R
+++ b/inst/apps/194-plot-cache-key/tests/testthat/test-mytest.R
@@ -5,31 +5,31 @@ test_that("Migrated shinytest test: mytest.R", {
     seed = 100, shiny_args = list(display.mode = "normal"))
 
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(n = 250)
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(n = 100)
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(newdata = "click")
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(n = 300)
   app$set_inputs(`reactlog_module-refresh` = "click")
-  Sys.sleep(4)
+  Sys.sleep(4) # wait for reactlog to settle
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/200-flexdashboard-render-text/tests/testthat/test-mytest.R
+++ b/inst/apps/200-flexdashboard-render-text/tests/testthat/test-mytest.R
@@ -4,15 +4,14 @@ test_that("Migrated shinytest test: mytest.R", {
   app <- AppDriver$new("../../index.Rmd", variant = shinytest2::platform_variant(),
     seed = 75237)
 
-  app$wait_for_value(input = "plotly_afterplot-A")
   # wait some more time just to let the images adjust
-  Sys.sleep(5)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
 
   app$set_inputs(month = "Mar")
   # wait some more time just to let the images adjust
-  Sys.sleep(5)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
 
@@ -20,7 +19,7 @@ test_that("Migrated shinytest test: mytest.R", {
   app$run_js(script = "$(\"#navbar li a\").last().click();", timeout = 10000)
   app$wait_for_value(output = "p2r1content")
   # wait some more time just to let the images adjust
-  Sys.sleep(5)
+  app$wait_for_idle()
   app$expect_values()
   app$expect_screenshot()
 })

--- a/inst/apps/303-bslib-html-template/tests/testthat/test-mytest.R
+++ b/inst/apps/303-bslib-html-template/tests/testthat/test-mytest.R
@@ -21,12 +21,12 @@ test_that("Migrated shinytest test: mytest.R", {
 
   wait_til_open <- function(css = ".selectize-dropdown-content *") {
     app$wait_for_js(paste0("$(\"", css, "\").length > 0"), timeout = 3000)
+    Sys.sleep(1) # wait for dropdown
   }
 
   # Take snapshot of dropdown once it has content
   app$run_js(script = "$('#select')[0].selectize.open()", timeout = 10000)
   wait_til_open()
-  Sys.sleep(1)
   app$expect_values()
   app$expect_screenshot()
 
@@ -35,7 +35,6 @@ test_that("Migrated shinytest test: mytest.R", {
   app$run_js(script = "$('#select_multiple')[0].selectize.open()",
     timeout = 10000)
   wait_til_open()
-  Sys.sleep(1)
   app$expect_values()
   app$expect_screenshot()
 


### PR DESCRIPTION
cc @MadhulikaTanuboddi 

Changed app 122 from a fixed sleep length to a `app$wait_for_idle()`. Then went through all other apps with a call to `Sys.sleep()` and changed them to `$wait_for_idle()` or added a comment on why the sleep is there.