### PR TITLE
Add the plot interaction apps back to the manual list

### DIFF
--- a/inst/apps/093-plot-interaction-basic/app.R
+++ b/inst/apps/093-plot-interaction-basic/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 library(ggplot2)
 
 ui <- fluidPage(

--- a/inst/apps/094-image-interaction-basic/app.R
+++ b/inst/apps/094-image-interaction-basic/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 library(png)
 
 ui <- fluidPage(

--- a/inst/apps/096-plot-interaction-article-1/app.R
+++ b/inst/apps/096-plot-interaction-article-1/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 library(shiny)
 
 ui <- basicPage(

--- a/inst/apps/097-plot-interaction-article-2/app.R
+++ b/inst/apps/097-plot-interaction-article-2/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 ui <- basicPage(
   plotOutput("plot1",
     click = "plot_click",

--- a/inst/apps/098-plot-interaction-article-3/app.R
+++ b/inst/apps/098-plot-interaction-article-3/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 ui <- basicPage(
   plotOutput("plot1", click = "plot_click"),
   verbatimTextOutput("info")

--- a/inst/apps/099-plot-interaction-article-4/app.R
+++ b/inst/apps/099-plot-interaction-article-4/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 library(ggplot2)
 ui <- basicPage(
   plotOutput("plot1", click = "plot_click"),

--- a/inst/apps/100-plot-interaction-article-5/app.R
+++ b/inst/apps/100-plot-interaction-article-5/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 ui <- basicPage(
   plotOutput("plot1", brush = "plot_brush"),
   verbatimTextOutput("info")

--- a/inst/apps/101-plot-interaction-article-6/app.R
+++ b/inst/apps/101-plot-interaction-article-6/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 library(ggplot2)
 ui <- basicPage(
   plotOutput("plot1", brush = "plot_brush", height = 250),

--- a/inst/apps/102-plot-interaction-article-7/app.R
+++ b/inst/apps/102-plot-interaction-article-7/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 library(ggplot2)
 ui <- basicPage(
   plotOutput("plot1", brush = "plot_brush"),

--- a/inst/apps/103-plot-interaction-article-8/app.R
+++ b/inst/apps/103-plot-interaction-article-8/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 library(ggplot2)
 ui <- basicPage(
   plotOutput("plot1",

--- a/inst/apps/104-plot-interaction-select/app.R
+++ b/inst/apps/104-plot-interaction-select/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 library(ggplot2)
 
 # We'll use a subset of the mtcars data set, with fewer columns

--- a/inst/apps/105-plot-interaction-zoom/app.R
+++ b/inst/apps/105-plot-interaction-zoom/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 library(ggplot2)
 
 ui <- fluidPage(

--- a/inst/apps/106-plot-interaction-exclude/app.R
+++ b/inst/apps/106-plot-interaction-exclude/app.R
@@ -1,3 +1,5 @@
+### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
+
 library(ggplot2)
 
 ui <- fluidPage(


### PR DESCRIPTION
Following upon https://github.com/rstudio/shinycoreci/commit/c198ecb410ec70521ac6626c7a116bb1a3304938, the GHA test runs started failing due to errors from "inst/gha/validate-test-files.R"

This is happening especially with any of the plot interaction based apps because these apps does not have any automated tests and from the commit above, we marked them as non-manual tests (in other words automated) just to have these apps not show up in our "shinycoreci::test_in_<xyz>" functions (when the team does the release testing). However, that caused the GHA test builds to fail because the validate script mentioned above looks for "tests" folder for any non-manual app.

Ref: https://github.com/rstudio/shinycoreci/runs/7174522879?check_suite_focus=true

<img width="1276" alt="Screen Shot 2022-07-05 at 11 22 37 AM" src="https://user-images.githubusercontent.com/5369655/177433586-ea25643a-38a4-4dca-9093-46a018ac8456.png">


So, we decided to revert the changes for only these plot based apps (other apps have atleast one of the shinytest2 or shinyjster tests) and hence this PR. 