### PR TITLE
`bslib::accordion()` tests

### DIFF
--- a/R/data-apps-deps.R
+++ b/R/data-apps-deps.R
@@ -58,4 +58,4 @@ apps_deps_map <- list(`001-hello` = "rsconnect", `012-datatables` = "ggplot2",
     "rversions", "sf", "withr"), `302-bootswatch-themes` = c("ggplot2", 
     "progress", "rversions", "sf", "withr"), `304-bslib-card` = c("rlang", 
     "rversions"), `305-bslib-value-box` = c("rlang", "rversions"
-    ))
+    ), `306-accordion-add-remove` = "rlang")

--- a/inst/apps/306-accordion-add-remove/app.R
+++ b/inst/apps/306-accordion-add-remove/app.R
@@ -9,12 +9,12 @@ make_item <- function(x) {
   )
 }
 
-ui <- page_fluid(
+ui <- fluidPage(
   # Don't transition when collapsing (so that we don't have
   # to wait to take screenshots)
   theme = bs_theme("transition-collapse" = "none"),
-  layout_sidebar(
-    list(
+  sidebarLayout(
+    sidebarPanel(
       selectInput(
         "selected", "Selected section(s)",
         LETTERS, multiple = TRUE, selected = "A"
@@ -26,7 +26,7 @@ ui <- page_fluid(
       checkboxInput("autoclose", "Auto closing accordion", FALSE),
       checkboxInput("insert_select", "Show on insert", FALSE)
     ),
-    uiOutput("accordion")
+    mainPanel(uiOutput("accordion"))
   )
 )
 

--- a/inst/apps/306-accordion-add-remove/app.R
+++ b/inst/apps/306-accordion-add-remove/app.R
@@ -106,9 +106,12 @@ server <- function(input, output, session) {
     }
 
     displayed(input$displayed)
+  })
 
+  observeEvent(displayed(), ignoreInit = TRUE, {
+    updateSelectInput(inputId = "displayed", selected = displayed())
     updateSelectInput(
-      inputId = "selected", choices = input$displayed,
+      inputId = "selected", choices = displayed(),
       selected = input$selected
     )
   })

--- a/inst/apps/306-accordion-add-remove/app.R
+++ b/inst/apps/306-accordion-add-remove/app.R
@@ -14,7 +14,6 @@ ui <- page_fill(
     border_radius = FALSE,
     border = FALSE,
     bg = "lightgray",
-    # TODO: put an accordion in here, just to test the layout_sidebar() CSS?
     sidebar(
       bg = "#1E1E1E",
       accordion(

--- a/inst/apps/306-accordion-add-remove/app.R
+++ b/inst/apps/306-accordion-add-remove/app.R
@@ -1,0 +1,85 @@
+library(shiny)
+library(bslib)
+
+make_item <- function(x) {
+  accordion_item(
+    paste("Section", x),
+    paste("Some narrative for section", x),
+    value = x
+  )
+}
+
+ui <- page_fluid(
+  # Don't transition when collapsing (so that we don't have
+  # to wait to take screenshots)
+  theme = bs_theme("transition-collapse" = "none"),
+  layout_sidebar(
+    list(
+      selectInput(
+        "selected", "Selected section(s)",
+        LETTERS, multiple = TRUE, selected = "A"
+      ),
+      selectInput(
+        "displayed", "Displayed section(s)",
+        LETTERS, multiple = TRUE, selected = LETTERS
+      ),
+      checkboxInput("autoclose", "Auto closing accordion", FALSE),
+      checkboxInput("insert_select", "Show on insert", FALSE)
+    ),
+    uiOutput("accordion")
+  )
+)
+
+server <- function(input, output, session) {
+
+  output$accordion <- renderUI({
+    displayed(LETTERS)
+
+    accordion(
+      id = "acc", autoclose = input$autoclose,
+      !!!lapply(LETTERS, make_item)
+    )
+  })
+
+  observeEvent(input$selected, {
+    accordion_select("acc", selected = input$selected)
+  })
+
+  displayed <- reactiveVal(LETTERS)
+
+  observeEvent(input$displayed, {
+    exit <- setdiff(displayed(), input$displayed)
+    enter <- setdiff(input$displayed, displayed())
+
+    if (length(exit)) {
+      accordion_remove("acc", target = exit)
+    }
+
+    if (length(enter)) {
+      lapply(enter, function(x) {
+        # Find the next lowest currently displayed letter (to insert after)
+        idx_displayed <- which(LETTERS %in% displayed())
+        idx_insert <- match(x, LETTERS)
+        idx_diff <- idx_insert - idx_displayed
+        idx_diff[idx_diff < 0] <- NA
+        target <- LETTERS[idx_displayed[which.min(idx_diff)]]
+        accordion_insert("acc", item = make_item(x), target = target)
+        displayed(c(x, displayed()))
+      })
+
+      if (input$insert_select) {
+        accordion_select("acc", enter, close = input$autoclose)
+      }
+    }
+
+    displayed(input$displayed)
+
+    updateSelectInput(
+      inputId = "selected", choices = input$displayed,
+      selected = input$selected
+    )
+  })
+
+}
+
+shinyApp(ui, server)

--- a/inst/apps/306-accordion-add-remove/tests/testthat.R
+++ b/inst/apps/306-accordion-add-remove/tests/testthat.R
@@ -1,0 +1,1 @@
+shinytest2::test_app()

--- a/inst/apps/306-accordion-add-remove/tests/testthat/setup-shinytest2.R
+++ b/inst/apps/306-accordion-add-remove/tests/testthat/setup-shinytest2.R
@@ -1,0 +1,2 @@
+# Load application support files into testing environment
+shinytest2::load_app_env()

--- a/inst/apps/306-accordion-add-remove/tests/testthat/test-shinytest2.R
+++ b/inst/apps/306-accordion-add-remove/tests/testthat/test-shinytest2.R
@@ -12,8 +12,8 @@ test_that("{shinytest2} recording: accordion-select", {
     options = list(bslib.precompiled = FALSE)
   )
 
-  expect_screenshot <- function(..., wait = 1, viewport = TRUE, threshold = 3) {
-    Sys.sleep(wait)
+  expect_screenshot <- function(..., duration = 500, viewport = TRUE, threshold = 3) {
+    app$wait_for_idle(duration = duration)
     args <- rlang::list2(..., threshold = threshold)
     if (viewport) {
       rect <- c(x = 0, y = 0, width = width, height = height)

--- a/inst/apps/306-accordion-add-remove/tests/testthat/test-shinytest2.R
+++ b/inst/apps/306-accordion-add-remove/tests/testthat/test-shinytest2.R
@@ -24,21 +24,23 @@ test_that("{shinytest2} recording: accordion-select", {
     do.call(app$expect_screenshot, args)
   }
 
-  # Test accordion_select()
+  # Test accordion_panel_set()
+  app$set_inputs(selected = c("A", "D"))
   app$set_inputs(selected = c("A", "D", "H"))
   expect_screenshot()
 
-  # Test accordion_remove()
+  # Test accordion_panel_remove()
   app$set_inputs(displayed = c("A", "D", "F"))
-  # Test accordion_insert()
+  # Test accordion_panel_insert()
   app$set_inputs(displayed = c("A", "D", "F", "Z"))
-  # Test accordion_insert(select = TRUE)
-  app$set_inputs(insert_select = TRUE)
+  # Test accordion_panel_insert() + accordion_panel_open()
+  app$set_inputs(open_on_insert = TRUE)
+  app$set_inputs(displayed = c("A", "D", "F", "J", "Z"))
   app$set_inputs(displayed = c("A", "D", "F", "J", "K", "Z"))
   expect_screenshot()
 
   # redo tests with accordion(autoclose = TRUE)
-  app$set_inputs(insert_select = FALSE)
+  app$set_inputs(open_on_insert = FALSE)
   app$set_inputs(multiple = FALSE)
   app$set_inputs(displayed = LETTERS)
 
@@ -47,7 +49,8 @@ test_that("{shinytest2} recording: accordion-select", {
   app$set_inputs(selected = c("C", "D"))
 
   app$set_inputs(displayed = c("A", "D", "F", "Z"))
-  app$set_inputs(insert_select = TRUE)
+  app$set_inputs(open_on_insert = TRUE)
+  app$set_inputs(displayed = c("A", "D", "F", "J", "Z"))
   app$set_inputs(displayed = c("A", "D", "F", "J", "K", "Z"))
   expect_screenshot()
 })

--- a/inst/apps/306-accordion-add-remove/tests/testthat/test-shinytest2.R
+++ b/inst/apps/306-accordion-add-remove/tests/testthat/test-shinytest2.R
@@ -1,0 +1,53 @@
+library(shinytest2)
+
+test_that("{shinytest2} recording: accordion-select", {
+  width <- 995
+  height <- 1336
+
+
+  app <- AppDriver$new(
+    variant = platform_variant(), name = "accordion-select", 
+    height = height, width = width,
+    view = interactive(),
+    options = list(bslib.precompiled = FALSE)
+  )
+
+  expect_screenshot <- function(..., wait = 1, viewport = TRUE, threshold = 3) {
+    Sys.sleep(wait)
+    args <- rlang::list2(..., threshold = threshold)
+    if (viewport) {
+      rect <- c(x = 0, y = 0, width = width, height = height)
+      new_args <- list(screenshot_args = list(cliprect = rect))
+      args <- modifyList(new_args, args)
+    }
+    # TODO: !!! doesn't work here?
+    do.call(app$expect_screenshot, args)
+  }
+
+  # Test accordion_select()
+  app$set_inputs(selected = c("A", "D", "H"))
+  expect_screenshot()
+
+  # Test accordion_remove()
+  app$set_inputs(displayed = c("A", "D", "F"))
+  # Test accordion_insert()
+  app$set_inputs(displayed = c("A", "D", "F", "Z"))
+  # Test accordion_insert(select = TRUE)
+  app$set_inputs(insert_select = TRUE)
+  app$set_inputs(displayed = c("A", "D", "F", "J", "K", "Z"))
+  expect_screenshot()
+
+  # redo tests with accordion(autoclose = TRUE)
+  app$set_inputs(insert_select = FALSE)
+  app$set_inputs(autoclose = TRUE)
+  app$set_inputs(displayed = LETTERS)
+
+  # Last one (D) should be selected
+  app$set_inputs(selected = "B")
+  app$set_inputs(selected = c("C", "D"))
+
+  app$set_inputs(displayed = c("A", "D", "F", "Z"))
+  app$set_inputs(insert_select = TRUE)
+  app$set_inputs(displayed = c("A", "D", "F", "J", "K", "Z"))
+  expect_screenshot()
+})

--- a/inst/apps/306-accordion-add-remove/tests/testthat/test-shinytest2.R
+++ b/inst/apps/306-accordion-add-remove/tests/testthat/test-shinytest2.R
@@ -6,7 +6,7 @@ test_that("{shinytest2} recording: accordion-select", {
 
 
   app <- AppDriver$new(
-    variant = platform_variant(), name = "accordion-select", 
+    variant = platform_variant(), name = "accordion-select",
     height = height, width = width,
     view = interactive(),
     options = list(bslib.precompiled = FALSE)
@@ -39,7 +39,7 @@ test_that("{shinytest2} recording: accordion-select", {
 
   # redo tests with accordion(autoclose = TRUE)
   app$set_inputs(insert_select = FALSE)
-  app$set_inputs(autoclose = TRUE)
+  app$set_inputs(multiple = FALSE)
   app$set_inputs(displayed = LETTERS)
 
   # Last one (D) should be selected

--- a/inst/apps/306-accordion-add-remove/tests/testthat/test-shinytest2.R
+++ b/inst/apps/306-accordion-add-remove/tests/testthat/test-shinytest2.R
@@ -4,7 +4,6 @@ test_that("{shinytest2} recording: accordion-select", {
   width <- 995
   height <- 1336
 
-
   app <- AppDriver$new(
     variant = platform_variant(), name = "accordion-select",
     height = height, width = width,
@@ -20,7 +19,6 @@ test_that("{shinytest2} recording: accordion-select", {
       new_args <- list(screenshot_args = list(cliprect = rect))
       args <- modifyList(new_args, args)
     }
-    # TODO: !!! doesn't work here?
     do.call(app$expect_screenshot, args)
   }
 
@@ -30,8 +28,9 @@ test_that("{shinytest2} recording: accordion-select", {
   expect_screenshot()
 
   # Test accordion_panel_remove()
-  app$set_inputs(displayed = c("A", "D", "F"))
+  app$set_inputs(displayed = c("D", "F"))
   # Test accordion_panel_insert()
+  app$set_inputs(displayed = c("A", "D", "F"))
   app$set_inputs(displayed = c("A", "D", "F", "Z"))
   # Test accordion_panel_insert() + accordion_panel_open()
   app$set_inputs(open_on_insert = TRUE)
@@ -42,11 +41,11 @@ test_that("{shinytest2} recording: accordion-select", {
   # redo tests with accordion(autoclose = TRUE)
   app$set_inputs(open_on_insert = FALSE)
   app$set_inputs(multiple = FALSE)
-  app$set_inputs(displayed = LETTERS)
 
   # Last one (D) should be selected
   app$set_inputs(selected = "B")
   app$set_inputs(selected = c("C", "D"))
+  expect_screenshot()
 
   app$set_inputs(displayed = c("A", "D", "F", "Z"))
   app$set_inputs(open_on_insert = TRUE)

--- a/inst/apps/306-accordion-add-remove/tests/testthat/test-shinytest2.R
+++ b/inst/apps/306-accordion-add-remove/tests/testthat/test-shinytest2.R
@@ -11,45 +11,40 @@ test_that("{shinytest2} recording: accordion-select", {
     options = list(bslib.precompiled = FALSE)
   )
 
-  expect_screenshot <- function(..., duration = 500, viewport = TRUE, threshold = 3) {
-    app$wait_for_idle(duration = duration)
-    args <- rlang::list2(..., threshold = threshold)
-    if (viewport) {
-      rect <- c(x = 0, y = 0, width = width, height = height)
-      new_args <- list(screenshot_args = list(cliprect = rect))
-      args <- modifyList(new_args, args)
-    }
-    do.call(app$expect_screenshot, args)
+  # Make sure the set_input() calls complete in order
+  set_inputs <- function(...) {
+    app$set_inputs(...)
+    app$wait_for_idle()
   }
 
   # Test accordion_panel_set()
-  app$set_inputs(selected = c("A", "D"))
-  app$set_inputs(selected = c("A", "D", "H"))
-  expect_screenshot()
+  set_inputs(selected = c("A", "D"))
+  set_inputs(selected = c("A", "D", "H"))
+  app$expect_screenshot()
 
   # Test accordion_panel_remove()
-  app$set_inputs(displayed = c("D", "F"))
+  set_inputs(displayed = c("D", "F"))
   # Test accordion_panel_insert()
-  app$set_inputs(displayed = c("A", "D", "F"))
-  app$set_inputs(displayed = c("A", "D", "F", "Z"))
+  set_inputs(displayed = c("A", "D", "F"))
+  set_inputs(displayed = c("A", "D", "F", "Z"))
   # Test accordion_panel_insert() + accordion_panel_open()
-  app$set_inputs(open_on_insert = TRUE)
-  app$set_inputs(displayed = c("A", "D", "F", "J", "Z"))
-  app$set_inputs(displayed = c("A", "D", "F", "J", "K", "Z"))
-  expect_screenshot()
+  set_inputs(open_on_insert = TRUE)
+  set_inputs(displayed = c("A", "D", "F", "J", "Z"))
+  set_inputs(displayed = c("A", "D", "F", "J", "K", "Z"))
+  app$expect_screenshot()
 
   # redo tests with accordion(autoclose = TRUE)
-  app$set_inputs(open_on_insert = FALSE)
-  app$set_inputs(multiple = FALSE)
+  set_inputs(open_on_insert = FALSE)
+  set_inputs(multiple = FALSE)
 
   # Last one (D) should be selected
-  app$set_inputs(selected = "B")
-  app$set_inputs(selected = c("C", "D"))
-  expect_screenshot()
+  set_inputs(selected = "B")
+  set_inputs(selected = c("C", "D"))
+  app$expect_screenshot()
 
-  app$set_inputs(displayed = c("A", "D", "F", "Z"))
-  app$set_inputs(open_on_insert = TRUE)
-  app$set_inputs(displayed = c("A", "D", "F", "J", "Z"))
-  app$set_inputs(displayed = c("A", "D", "F", "J", "K", "Z"))
-  expect_screenshot()
+  set_inputs(displayed = c("A", "D", "F", "Z"))
+  set_inputs(open_on_insert = TRUE)
+  set_inputs(displayed = c("A", "D", "F", "J", "Z"))
+  set_inputs(displayed = c("A", "D", "F", "J", "K", "Z"))
+  app$expect_screenshot()
 })

--- a/inst/apps/307-accordion-replace/app.R
+++ b/inst/apps/307-accordion-replace/app.R
@@ -6,7 +6,7 @@ ui <- page_fluid(
   tags$style(".accordion {--bs-accordion-active-color: #dc3545; --bs-accordion-active-bg: rgba(220, 53, 69, 0.05)}"),
   accordion(
     id = "acc",
-    accordion_item(
+    accordion_panel(
       title = "Test failed",
       icon = bs_icon("x-circle"),
       value = "test-message",
@@ -31,7 +31,7 @@ server <- function(input, output, session) {
   shinyjster::shinyjster_server(input, output)
 
   observe({
-    accordion_replace(
+    accordion_panel_update(
       id = "acc", target = "test-message",
       title = "Test passed",
       icon = bs_icon("check-circle"),

--- a/inst/apps/307-accordion-replace/app.R
+++ b/inst/apps/307-accordion-replace/app.R
@@ -1,0 +1,46 @@
+library(shiny)
+library(bslib)
+library(bsicons)
+
+ui <- page_fluid(
+  tags$style(".accordion {--bs-accordion-active-color: #dc3545; --bs-accordion-active-bg: rgba(220, 53, 69, 0.05)}"),
+  accordion(
+    id = "acc",
+    accordion_item(
+      title = "Test failed",
+      icon = bs_icon("x-circle"),
+      value = "test-message",
+      "Try again"
+    )
+  ),
+  shinyjster::shinyjster_js("
+    var jst = jster(0);
+    jst.add(Jster.shiny.waitUntilStable);
+    jst.add(function() {
+      Jster.assert.isEqual(
+        $('#acc .accordion-button').text(), 'Test passed',
+        'accordion_mutate() did not update the accordion()'
+      );
+    });
+    jst.test();
+  ")
+)
+
+server <- function(input, output, session) {
+
+  shinyjster::shinyjster_server(input, output)
+
+  observe({
+    accordion_replace(
+      id = "acc", target = "test-message",
+      title = "Test passed",
+      icon = bs_icon("check-circle"),
+      "Nicely done!"
+    )
+
+    insertUI("body", ui = tags$style(".accordion {--bs-accordion-active-color: #198754; --bs-accordion-active-bg: rgba(25, 135, 84, 0.05) !important}"))
+  })
+
+}
+
+shinyApp(ui, server)

--- a/inst/apps/307-accordion-replace/app.R
+++ b/inst/apps/307-accordion-replace/app.R
@@ -18,7 +18,7 @@ ui <- page_fluid(
     jst.add(Jster.shiny.waitUntilStable);
     jst.add(function() {
       Jster.assert.isEqual(
-        $('#acc .accordion-button').text(), 'Test passed',
+        $('#acc .accordion-button').text().trim(), 'Test passed',
         'accordion_mutate() did not update the accordion()'
       );
     });

--- a/inst/apps/307-accordion-replace/tests/testthat.R
+++ b/inst/apps/307-accordion-replace/tests/testthat.R
@@ -1,0 +1,1 @@
+shinytest2::test_app()

--- a/inst/apps/307-accordion-replace/tests/testthat/setup.R
+++ b/inst/apps/307-accordion-replace/tests/testthat/setup.R
@@ -1,0 +1,2 @@
+# Load application support files into testing environment
+shinytest2::load_app_env()

--- a/inst/apps/307-accordion-replace/tests/testthat/test-shinyjster.R
+++ b/inst/apps/307-accordion-replace/tests/testthat/test-shinyjster.R
@@ -1,0 +1,1 @@
+shinyjster::testthat_shinyjster("Execute hidden plot")


### PR DESCRIPTION
This PR adds two tests:

1. `306-accordion-add-remove`: This app primarily tests `accordion_panel_insert()`, `accordion_panel_remove()`, `accordion_panel_set()`, and `accordion_panel_open()`. It also takes screenshots (instead of testing markup) since it implicitly depends on compliance with Bootstrap markup. Note that we also use an `accordion()` inside a `sidebar()` here to ensure it renders flush with the sidebar.
2. `307-accordion-replace`: Primarily tests `accordion_panel_update()`
