### PR TITLE
Use `{sessioninfo}` to save sysinfo files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Imports:
     progress,
     callr,
     sessioninfo,
-    rstudioapi (>= 0.11)
+    rstudioapi (>= 0.11),
+    cli
 Suggests:
     renv,
     httpuv,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Authors@R: c(
     person("Winston", "Chang", role = "aut", email = "winston@rstudio.com"),
     person("Alan", "Dipert", role = "aut", email = "alan@rstudio.com"),
     person("RStudio", role = c("cph", "fnd")))
-Description: What the package does (one paragraph).
+Description: Core shiny team tools to facilitate testing of the shiny-verse.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/R/deploy-apps.R
+++ b/R/deploy-apps.R
@@ -182,8 +182,6 @@ deploy_apps <- function(
 
 
 validate_rsconnect_account <- function(account, server) {
-  check_installed("rsconnect")
-
   accts <- rsconnect::accounts()
   accts_found <- sum(
     (account %in% accts$name) &

--- a/R/deploy-connect-urls.R
+++ b/R/deploy-connect-urls.R
@@ -75,8 +75,6 @@ connect_urls <- function(
   account = "barret",
   server = "beta.rstudioconnect.com"
 ) {
-  check_installed("rsconnect")
-
   # apps_dirs <- file.path(dir, apps)
   apps <- vapply(apps, resolve_app_name, character(1))
 
@@ -99,8 +97,6 @@ connect_urls <- function(
 
 
 api_get_ <- function(server, api_key) {
-  check_installed("rsconnect")
-
   server_url <- rsconnect::serverInfo(server)$url
   function(route) {
     req <- httr::GET(
@@ -114,8 +110,6 @@ api_get_ <- function(server, api_key) {
   }
 }
 api_post_ <- function(server, api_key) {
-  check_installed("rsconnect")
-
   server_url <- rsconnect::serverInfo(server)$url
   function(route, body) {
     req <- httr::POST(

--- a/R/install.R
+++ b/R/install.R
@@ -1,10 +1,8 @@
-is_installed <- function(package, libpath = .libPaths()[1]) {
+# This method should **not** be used outside of this file
+# Only check if the package is installed in the `libpath`.
+# `package` may be installed in another libpath
+is_installed <- function(package, libpath) {
   nzchar(system.file(package = package, lib.loc = libpath))
-}
-check_installed <- function(package, libpath = .libPaths()[1]) {
-  if (!is_installed(package, libpath = libpath)) {
-    stop(package, " is not installed and is required by `shinycoreci`")
-  }
 }
 
 

--- a/R/sysinfo.R
+++ b/R/sysinfo.R
@@ -1,9 +1,10 @@
 #' Write system information to a file
 #'
 #' @param file Name of file, or file object to write to (defaults to stdout).
-#' @param libpath Library path to find installaed packages.
+#' @param libpath Library path to find installed packages.
 #' @export
 write_sysinfo <- function(file = stdout(), libpath = shinyverse_libpath()) {
+  withr::local_libpaths(libpath, action = "prefix")
 
   opts <- options()
   on.exit(options(opts))

--- a/R/sysinfo.R
+++ b/R/sysinfo.R
@@ -6,10 +6,6 @@
 write_sysinfo <- function(file = stdout(), libpath = shinyverse_libpath()) {
   withr::local_libpaths(libpath, action = "prefix")
 
-  opts <- options()
-  on.exit(options(opts))
-  options(width = 1000)
-
   platform_info <- sessioninfo::platform_info()
   platform_info_cls <- class(platform_info)
   # Shim in the GitHub Actions image version

--- a/R/sysinfo.R
+++ b/R/sysinfo.R
@@ -4,7 +4,6 @@
 #' @param libpath Library path to find installaed packages.
 #' @export
 write_sysinfo <- function(file = stdout(), libpath = shinyverse_libpath()) {
-  check_installed("sessioninfo")
 
   opts <- options()
   on.exit(options(opts))

--- a/R/test-in-ide.R
+++ b/R/test-in-ide.R
@@ -27,16 +27,18 @@ test_in_ide <- function(
   sys_call <- match.call()
   apps <- resolve_app_name(apps)
 
-  local_libpath <- if (isTRUE(refresh_)) {
-    if (isTRUE(local_pkgs)) {
-      install_shinyverse(install = FALSE)
+  local_libpath <-
+    if (isTRUE(refresh_)) {
+      if (isTRUE(local_pkgs)) {
+        install_shinyverse(install = FALSE)
+      } else {
+        shinyverse_libpath()
+      }
     } else {
-      shinyverse_libpath()
+      # First time though
+      install_shinyverse(install = !isTRUE(local_pkgs), validate_loaded = TRUE)
     }
-  } else {
-    # First time though
-    install_shinyverse(install = !isTRUE(local_pkgs), validate_loaded = TRUE)
-  }
+  withr::local_libpaths(local_libpath, action = "prefix")
 
   app_name <- resolve_app_name(app_name)
 

--- a/R/triple_colon.R
+++ b/R/triple_colon.R
@@ -14,10 +14,6 @@ triple_colon <- function(pkg, name) {
 # }
 
 
-renv__renv_snapshot_r_packages <- function(...) {
-  triple_colon("renv", "renv_snapshot_r_packages")(...)
-}
-
 base__library <- function(...) {
   triple_colon("base", "library")(...)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,26 +22,6 @@ is_sha <- function(x) {
     sub("[0-9a-f]*", "", x) == ""
 }
 
-# Given a d3-format list and the name of an item in each sublist, return a
-# vector containing the corresponding item from each sublist. If the value is
-# not present or NULL, it will be filled in with NA.
-extract_vector <- function(x, name) {
-  vecs <- lapply(x, function(y) {
-    value <- y[[name]]
-    if (is.null(value)) value <- NA
-    value
-  })
-  do.call(c, vecs)
-}
-
-# Convert d3-format nested list to data frame. The column names must be
-# supplied by the caller.
-d3_to_df <- function(x, colnames) {
-  names(colnames) <- colnames
-  res <- lapply(colnames, function(colname) extract_vector(x, colname))
-  as.data.frame(res, stringsAsFactors = FALSE)
-}
-
 
 # Ask a yes no question defaulting to 'no'
 ask_yes_no <- function(..., default = FALSE) {

--- a/inst/apps/001-hello/app.R
+++ b/inst/apps/001-hello/app.R
@@ -83,6 +83,5 @@ server <- function(input, output, session) {
 }
 
 
-
 # Create Shiny app ----
 shinyApp(ui = ui, server = server)

--- a/inst/apps/001-hello/app.R
+++ b/inst/apps/001-hello/app.R
@@ -83,5 +83,6 @@ server <- function(input, output, session) {
 }
 
 
+
 # Create Shiny app ----
 shinyApp(ui = ui, server = server)

--- a/man/write_sysinfo.Rd
+++ b/man/write_sysinfo.Rd
@@ -9,7 +9,7 @@ write_sysinfo(file = stdout(), libpath = shinyverse_libpath())
 \arguments{
 \item{file}{Name of file, or file object to write to (defaults to stdout).}
 
-\item{libpath}{Library path to find installaed packages.}
+\item{libpath}{Library path to find installed packages.}
 }
 \description{
 Write system information to a file

--- a/tests/testthat/test-sysinfo.R
+++ b/tests/testthat/test-sysinfo.R
@@ -1,0 +1,10 @@
+test_that("sysinfo can be written", {
+
+    sys_info_file <- tempfile()
+    on.exit(unlink(sys_info_file))
+
+    write_sysinfo(sys_info_file)
+
+    expect_true(file.exists(sys_info_file))
+    expect_true(file.info(sys_info_file)$size > 0)
+})


### PR DESCRIPTION
Given `{renv}` 17, we get this error when saving the sys info

```
2023-03-23T06:57:39.7327400Z Stopping tests for app: 302-bootswatch-themes
2023-03-23T06:57:39.7328110Z ###
2023-03-23T06:57:40.2999050Z Error in triple_colon("renv", "renv_snapshot_r_packages")(...) : 
2023-03-23T06:57:40.2999910Z   attempt to apply non-function
2023-03-23T06:57:40.3000540Z Calls: <Anonymous> -> <Anonymous>
```

`renv:::renv_snapshot_r_packages()` no longer exists.

I finally shot myself in the foot. 🦶 🔫 