### PR TITLE
Use `list()` instead of `c()` for option groups in `selectizeInput`

### DIFF
--- a/inst/apps/024-optgroup-selectize/server.R
+++ b/inst/apps/024-optgroup-selectize/server.R
@@ -1,7 +1,7 @@
 function(input, output, session) {
   updateSelectizeInput(session, 'x2', choices = list(
-    Eastern = c(`Rhode Island` = 'RI', `New Jersey` = 'NJ'),
-    Western = c(`Oregon` = 'OR', `Washington` = 'WA'),
+    Eastern = list(`Rhode Island` = 'RI', `New Jersey` = 'NJ'),
+    Western = list(`Oregon` = 'OR', `Washington` = 'WA'),
     Middle = list(Iowa = 'IA')
   ), selected = 'IA')
 

--- a/inst/apps/024-optgroup-selectize/ui.R
+++ b/inst/apps/024-optgroup-selectize/ui.R
@@ -2,8 +2,8 @@ fluidPage(sidebarLayout(
   sidebarPanel(
     # use regions as option groups
     selectizeInput('x1', 'X1', choices = list(
-      Eastern = c(`New York` = 'NY', `New Jersey` = 'NJ'),
-      Western = c(`California` = 'CA', `Washington` = 'WA')
+      Eastern = list(`New York` = 'NY', `New Jersey` = 'NJ'),
+      Western = list(`California` = 'CA', `Washington` = 'WA')
     ), multiple = TRUE),
 
     # use updateSelectizeInput() to generate options later
@@ -14,8 +14,8 @@ fluidPage(sidebarLayout(
 
     # a select input
     selectInput('x4', 'X4', choices = list(
-      Eastern = c(`New York` = 'NY', `New Jersey` = 'NJ'),
-      Western = c(`California` = 'CA', `Washington` = 'WA')
+      Eastern = list(`New York` = 'NY', `New Jersey` = 'NJ'),
+      Western = list(`California` = 'CA', `Washington` = 'WA')
     ), selectize = FALSE)
   ),
   mainPanel(


### PR DESCRIPTION
With the current example code, users may run into this issue: https://github.com/rstudio/shiny/issues/3706

This change will direct people away from writing code like that.