### PR TITLE
Leverage themer-demo's env var to get legacy version of demo app

### DIFF
--- a/inst/apps/301-bs-themes/app.R
+++ b/inst/apps/301-bs-themes/app.R
@@ -5,5 +5,8 @@ library(ggplot2)
 library(sf)
 library(DT)
 
-
+# Get the 'original' version of this app from the bslib package
+# (so we don't have to update tests/screenshots)
+# https://github.com/rstudio/bslib/pull/572
+Sys.setenv("BSLIB_LEGACY_THEMER_APP" = TRUE)
 shinyAppDir(system.file("themer-demo", package = "bslib"))

--- a/inst/apps/302-bootswatch-themes/app.R
+++ b/inst/apps/302-bootswatch-themes/app.R
@@ -8,4 +8,9 @@ if (!require("thematic")) {
 library(ggplot2)
 library(sf)
 library(DT)
+
+# Get the 'original' version of this app from the bslib package
+# (so we don't have to update tests/screenshots)
+# https://github.com/rstudio/bslib/pull/572
+Sys.setenv("BSLIB_LEGACY_THEMER_APP" = TRUE)
 shinyAppDir(system.file("themer-demo", package = "bslib"))


### PR DESCRIPTION
See https://github.com/rstudio/bslib/pull/572

Note that `300-bs-themer` also uses `themer-demo`, but it's fine to have that one use the latest version of the demo app since it's a manual test