### PR TITLE
tests(313): Fix bslib full screen card selector

### DIFF
--- a/inst/apps/313-bslib-card-tab-focus/tests/testthat/test-313-bslib-card-tab-focus.R
+++ b/inst/apps/313-bslib-card-tab-focus/tests/testthat/test-313-bslib-card-tab-focus.R
@@ -65,12 +65,22 @@ expect_card_full_screen <- function(app, id) {
   invisible(app)
 }
 
-expect_no_full_screen <- function(app) {
+expect_no_full_screen <- function(app, id = NULL) {
   app$wait_for_js('!document.body.matches(".bslib-has-full-screen")')
   expect_equal(
     app$get_js("document.querySelectorAll('.bslib-card[data-full-screen=\"true\"]').length"),
     0
   )
+  if (is.null(id)) return(invisible(app))
+
+  expect_equal(
+    app$get_js(sprintf(
+      "document.getElementById('%s').getAttribute('data-full-screen')",
+      id
+    )),
+    "false"
+  )
+
   invisible(app)
 }
 
@@ -174,7 +184,7 @@ test_that("fullscreen card without internal focusable elements", {
 
   # Exit full screen
   key_press("Enter")
-  expect_no_full_screen(app)
+  expect_no_full_screen(app, id = "card-no-inputs")
 })
 
 # Test enter/exit methods ------------------------------------------

--- a/inst/apps/313-bslib-card-tab-focus/tests/testthat/test-313-bslib-card-tab-focus.R
+++ b/inst/apps/313-bslib-card-tab-focus/tests/testthat/test-313-bslib-card-tab-focus.R
@@ -34,14 +34,20 @@ expect_focus <- function(app, selector) {
 expect_card_full_screen <- function(app, id) {
   id <- sub("^#", "", id)
   app$wait_for_js('document.body.matches(".bslib-has-full-screen")')
+  # The expected card is expanded in full screen mode
   expect_equal(
-    app$get_js('document.querySelector(".bslib-full-screen").id'),
-    id
+    app$get_js(sprintf(
+     "document.getElementById('%s').getAttribute('data-full-screen')",
+      id
+    )),
+    "true"
   )
+  # Only one card is expanded to full screen
   expect_equal(
-    app$get_js("document.querySelectorAll('.bslib-full-screen').length"),
+    app$get_js("document.querySelectorAll('.bslib-card[data-full-screen=\"true\"]').length"),
     1
   )
+  # The overlay (behind card and above UI) is present
   expect_equal(
     app$get_js("document.querySelectorAll('#bslib-full-screen-overlay').length"),
     1
@@ -62,7 +68,7 @@ expect_card_full_screen <- function(app, id) {
 expect_no_full_screen <- function(app) {
   app$wait_for_js('!document.body.matches(".bslib-has-full-screen")')
   expect_equal(
-    app$get_js("document.querySelectorAll('.bslib-full-screen').length"),
+    app$get_js("document.querySelectorAll('.bslib-card[data-full-screen=\"true\"]').length"),
     0
   )
   invisible(app)


### PR DESCRIPTION
Fixes #192 

After rstudio/bslib#669, all full screen capable cards have `data-full-screen="false"`, which is updated to `"true"` when the card is expanded.

This PR updates the tests to use this new slector.