### PR TITLE
fix(313-bslib-card-tab-focus): Update selector for card full screen toggle button

### DIFF
--- a/inst/apps/313-bslib-card-tab-focus/tests/testthat/test-313-bslib-card-tab-focus.R
+++ b/inst/apps/313-bslib-card-tab-focus/tests/testthat/test-313-bslib-card-tab-focus.R
@@ -101,7 +101,7 @@ app_reset_no_full_screen <- function(app) {
 
 app_card_full_screen_enter <- function(app, id) {
   id <- sub("^#", "", id)
-  app$click(selector = sprintf("#%s > .bslib-full-screen-enter", id))
+  app$click(selector = sprintf("#%s > * > .bslib-full-screen-enter", id))
   expect_card_full_screen(app, id)
   invisible(app)
 }


### PR DESCRIPTION
Updates the selector for the card full screen toggle button, the structure of which was changed in https://github.com/rstudio/bslib/pull/662.

Fixes #195