### PR TITLE
Add 315-bslib-input-switch

### DIFF
--- a/inst/apps/315-bslib-input-switch/README.md
+++ b/inst/apps/315-bslib-input-switch/README.md
@@ -1,0 +1,3 @@
+## 315-bslib-input-switch
+
+`315-bslib-input-switch` tests `bslib::input_switch()`.

--- a/inst/apps/315-bslib-input-switch/app.R
+++ b/inst/apps/315-bslib-input-switch/app.R
@@ -3,17 +3,25 @@ library(bslib)
 
 ui <- page_fixed(
   title = "Keyboard Settings",
+
   h2("Keyboard Settings"),
   input_switch("auto_capitalization", "Auto-Capitalization", TRUE),
   input_switch("auto_correction", "Auto-Correction", FALSE),
   input_switch("check_spelling", "Check Spelling", TRUE),
   input_switch("smart_punctuation", "Smart Punctuation"),
+
   h2("Preview"),
   verbatimTextOutput("preview"),
-  h2("Update Methods"),
+
+  h2("toggle_switch()"),
   actionButton("toggle_spelling", "Toggle Spell Check"),
-  actionButton("enable_auto_correct", "Enable Auto correct"),
-  actionButton("disable_capitalization", "Disable Capitalization"),
+  actionButton("toggle_enable_auto_correct", "Enable Auto correct"),
+  actionButton("toggle_disable_capitalization", "Disable Capitalization"),
+
+  h2("update_switch()"),
+  actionButton("update_toggle_spelling", "Toggle Spell Check"),
+  actionButton("update_enable_auto_correct", "Enable Auto correct"),
+  actionButton("update_disable_capitalization", "Disable Capitalization"),
   textInput("smart_punct_label", "Smart Punctuation Label", "Smart Punctuation")
 )
 
@@ -27,37 +35,32 @@ server <- function(input, output, session) {
     )
   })
 
-  test_value_update <- function(...) {
-    fn <- switch(
-      getOption("value_update_type", "update"),
-      update = {
-        rlang::inform("testing using `update_switch()`")
-        update_switch
-      },
-      {
-        rlang::inform("testing using `toggle_switch()`")
-        toggle_switch
-      }
-    )
-
-    eval(rlang::call2(fn, ...))
-  }
-
-  observe({
-    req(input$value_update_type)
-    options(value_update_type = input$value_update_type)
-  })
+  # toggle_switch() -----------------------------------------------------------
 
   observeEvent(input$toggle_spelling, {
     toggle_switch("check_spelling")
   })
 
-  observeEvent(input$enable_auto_correct, {
-    test_value_update("auto_correction", value = TRUE)
+  observeEvent(input$toggle_enable_auto_correct, {
+    toggle_switch("auto_correction", value = TRUE)
   })
 
-  observeEvent(input$disable_capitalization, {
-    test_value_update("auto_capitalization", value = FALSE)
+  observeEvent(input$toggle_disable_capitalization, {
+    toggle_switch("auto_capitalization", value = FALSE)
+  })
+
+  # update_switch() -----------------------------------------------------------
+
+  observeEvent(input$update_toggle_spelling, {
+    update_switch("check_spelling", value = !input$check_spelling)
+  })
+
+  observeEvent(input$update_enable_auto_correct, {
+    update_switch("auto_correction", value = TRUE)
+  })
+
+  observeEvent(input$update_disable_capitalization, {
+    update_switch("auto_capitalization", value = FALSE)
   })
 
   observeEvent(input$smart_punct_label, {

--- a/inst/apps/315-bslib-input-switch/app.R
+++ b/inst/apps/315-bslib-input-switch/app.R
@@ -1,0 +1,57 @@
+library(shiny)
+library(bslib)
+
+ui <- page_fixed(
+  title = "Keyboard Settings",
+  h2("Keyboard Settings"),
+  input_switch("auto_capitalization", "Auto-Capitalization", TRUE),
+  input_switch("auto_correction", "Auto-Correction", FALSE),
+  input_switch("check_spelling", "Check Spelling", TRUE),
+  input_switch("smart_punctuation", "Smart Punctuation"),
+  h2("Preview"),
+  verbatimTextOutput("preview"),
+  h2("Update Methods"),
+  actionButton("toggle_spelling", "Toggle Spell Check"),
+  actionButton("enable_auto_correct", "Enable Auto correct"),
+  actionButton("disable_capitalization", "Disable Capitalization"),
+  textInput("smart_punct_label", "Smart Punctuation Label", "Smart Punctuation")
+)
+
+server <- function(input, output, session) {
+  output$preview <- renderPrint({
+    list(
+      auto_capitalization = input$auto_capitalization,
+      auto_correction = input$auto_correction,
+      check_spelling = input$check_spelling,
+      smart_punctuation = input$smart_punctuation
+    )
+  })
+
+  test_value_update <- function(...) {
+    fn <- switch(
+      getOption("value_update_type", "update"),
+      update = update_switch,
+      toggle_switch
+    )
+
+    eval(rlang::call2(fn, ...))
+  }
+
+  observeEvent(input$toggle_spelling, {
+    toggle_switch("check_spelling")
+  })
+
+  observeEvent(input$enable_auto_correct, {
+    test_value_update("auto_correction", value = TRUE)
+  })
+
+  observeEvent(input$disable_capitalization, {
+    test_value_update("auto_capitalization", value = FALSE)
+  })
+
+  observeEvent(input$smart_punct_label, {
+    update_switch("smart_punctuation", label = input$smart_punct_label)
+  })
+}
+
+shinyApp(ui, server)

--- a/inst/apps/315-bslib-input-switch/app.R
+++ b/inst/apps/315-bslib-input-switch/app.R
@@ -30,12 +30,23 @@ server <- function(input, output, session) {
   test_value_update <- function(...) {
     fn <- switch(
       getOption("value_update_type", "update"),
-      update = update_switch,
-      toggle_switch
+      update = {
+        rlang::inform("testing using `update_switch()`")
+        update_switch
+      },
+      {
+        rlang::inform("testing using `toggle_switch()`")
+        toggle_switch
+      }
     )
 
     eval(rlang::call2(fn, ...))
   }
+
+  observe({
+    req(input$value_update_type)
+    options(value_update_type = input$value_update_type)
+  })
 
   observeEvent(input$toggle_spelling, {
     toggle_switch("check_spelling")

--- a/inst/apps/315-bslib-input-switch/tests/testthat.R
+++ b/inst/apps/315-bslib-input-switch/tests/testthat.R
@@ -1,0 +1,1 @@
+shinytest2::test_app()

--- a/inst/apps/315-bslib-input-switch/tests/testthat/setup-shinytest2.R
+++ b/inst/apps/315-bslib-input-switch/tests/testthat/setup-shinytest2.R
@@ -1,0 +1,2 @@
+# Load application support files into testing environment
+shinytest2::load_app_env()

--- a/inst/apps/315-bslib-input-switch/tests/testthat/test-315-bslib-input-switch.R
+++ b/inst/apps/315-bslib-input-switch/tests/testthat/test-315-bslib-input-switch.R
@@ -78,6 +78,14 @@ test_that("update_switch(label = )", {
   app$
     set_inputs(smart_punct_label = "Awesome Punctuation")$
     wait_for_js(
-      "document.querySelector('label[for=\"smart_punctuation\"]').innerText === 'Awesome Punctuation'"
+      "document
+        .querySelector('label[for=\"smart_punctuation\"]')
+        .innerText
+        .includes('Awesome')"
+    )
+
+    expect_equal(
+      app$get_js('document.querySelector("label[for=\\"smart_punctuation\\"]").innerText'),
+      "Awesome Punctuation"
     )
 })

--- a/inst/apps/315-bslib-input-switch/tests/testthat/test-315-bslib-input-switch.R
+++ b/inst/apps/315-bslib-input-switch/tests/testthat/test-315-bslib-input-switch.R
@@ -1,0 +1,81 @@
+library(shinytest2)
+
+app <- AppDriver$new(
+  name = "315-bslib-input-switch",
+  variant = platform_variant(),
+  height = 1600,
+  width = 1200,
+  view = interactive(),
+  options = list(bslib.precompiled = FALSE),
+  expect_values_screenshot_args = FALSE
+)
+
+withr::defer(app$stop())
+
+set_input_if_not <- function(input, value) {
+  current <- app$get_value(input = input)
+  if (is.null(current) || !identical(current, value)) {
+    app$set_inputs(!!input := value)
+  }
+  expect_equal(app$get_value(input = input), value)
+  invisible(app)
+}
+
+test_that("initial values", {
+  expect_equal(
+    app$get_values(
+      input = c(
+        "auto_capitalization",
+        "auto_correction",
+        "check_spelling",
+        "smart_punctuation"
+      )
+    )$input,
+    list(
+      auto_capitalization = TRUE,
+      auto_correction = FALSE,
+      check_spelling = TRUE,
+      smart_punctuation = FALSE
+    )
+  )
+})
+
+test_that("toggle_switch()", {
+  set_input_if_not("check_spelling", TRUE)
+
+  app$click("toggle_spelling")
+  expect_false(app$get_value(input = "check_spelling"))
+
+  app$click("toggle_spelling")
+  expect_true(app$get_value(input = "check_spelling"))
+})
+
+test_that("toggle_switch(value = )", {
+  withr::local_options(list(value_update_type = "toggle"))
+
+  set_input_if_not("auto_correction", FALSE)
+  app$click("enable_auto_correct")
+  expect_true(app$get_value(input = "auto_correction"))
+
+  set_input_if_not("auto_capitalization", TRUE)
+  app$click("disable_capitalization")
+  expect_false(app$get_value(input = "auto_capitalization"))
+})
+
+test_that("update_switch(value = )", {
+  withr::local_options(list(value_update_type = "update"))
+
+  set_input_if_not("auto_correction", FALSE)
+  app$click("enable_auto_correct")
+  expect_true(app$get_value(input = "auto_correction"))
+
+  set_input_if_not("auto_capitalization", TRUE)
+  app$click("disable_capitalization")
+  expect_false(app$get_value(input = "auto_capitalization"))
+})
+
+test_that("update_switch(label = )", {
+  app$set_inputs(smart_punct_label = "Awesome Punctuation")
+  label <- app$get_text('label[for="smart_punctuation"]')
+  expect_equal(trimws(label), "Awesome Punctuation")
+})

--- a/inst/apps/315-bslib-input-switch/tests/testthat/test-315-bslib-input-switch.R
+++ b/inst/apps/315-bslib-input-switch/tests/testthat/test-315-bslib-input-switch.R
@@ -51,26 +51,26 @@ test_that("toggle_switch()", {
 })
 
 test_that("toggle_switch(value = )", {
-  app$run_js("Shiny.setInputValue('value_update_type', 'toggle')")
-
   set_input_if_not("auto_correction", FALSE)
-  app$click("enable_auto_correct")
+  app$click("toggle_enable_auto_correct")
   expect_true(app$get_value(input = "auto_correction"))
 
   set_input_if_not("auto_capitalization", TRUE)
-  app$click("disable_capitalization")
+  app$click("toggle_disable_capitalization")
   expect_false(app$get_value(input = "auto_capitalization"))
 })
 
 test_that("update_switch(value = )", {
-  app$run_js("Shiny.setInputValue('value_update_type', 'update')")
+  spelling_current <- app$get_value(input = "check_spelling")
+  app$click("update_toggle_spelling")
+  expect_equal(app$get_value(input = "check_spelling"), !spelling_current)
 
   set_input_if_not("auto_correction", FALSE)
-  app$click("enable_auto_correct")
+  app$click("update_enable_auto_correct")
   expect_true(app$get_value(input = "auto_correction"))
 
   set_input_if_not("auto_capitalization", TRUE)
-  app$click("disable_capitalization")
+  app$click("update_disable_capitalization")
   expect_false(app$get_value(input = "auto_capitalization"))
 })
 

--- a/inst/apps/315-bslib-input-switch/tests/testthat/test-315-bslib-input-switch.R
+++ b/inst/apps/315-bslib-input-switch/tests/testthat/test-315-bslib-input-switch.R
@@ -51,7 +51,7 @@ test_that("toggle_switch()", {
 })
 
 test_that("toggle_switch(value = )", {
-  withr::local_options(list(value_update_type = "toggle"))
+  app$run_js("Shiny.setInputValue('value_update_type', 'toggle')")
 
   set_input_if_not("auto_correction", FALSE)
   app$click("enable_auto_correct")
@@ -63,7 +63,7 @@ test_that("toggle_switch(value = )", {
 })
 
 test_that("update_switch(value = )", {
-  withr::local_options(list(value_update_type = "update"))
+  app$run_js("Shiny.setInputValue('value_update_type', 'update')")
 
   set_input_if_not("auto_correction", FALSE)
   app$click("enable_auto_correct")

--- a/inst/apps/315-bslib-input-switch/tests/testthat/test-315-bslib-input-switch.R
+++ b/inst/apps/315-bslib-input-switch/tests/testthat/test-315-bslib-input-switch.R
@@ -75,7 +75,9 @@ test_that("update_switch(value = )", {
 })
 
 test_that("update_switch(label = )", {
-  app$set_inputs(smart_punct_label = "Awesome Punctuation")
-  label <- app$get_text('label[for="smart_punctuation"]')
-  expect_equal(trimws(label), "Awesome Punctuation")
+  app$
+    set_inputs(smart_punct_label = "Awesome Punctuation")$
+    wait_for_js(
+      "document.querySelector('label[for=\"smart_punctuation\"]').innerText === 'Awesome Punctuation'"
+    )
 })


### PR DESCRIPTION
Adds tests around `bslib::input_switch()` and update methods

* https://github.com/rstudio/bslib/pull/483
* https://github.com/rstudio/bslib/issues/676