### PR TITLE
Fix Chrome/ChromeDriver version incompatibility

### DIFF
--- a/.github/workflows/apps-test-os.yml
+++ b/.github/workflows/apps-test-os.yml
@@ -124,9 +124,22 @@ jobs:
       # Temporarily install Chrome 114.0.5735.134 since shinyjster's webdrivermanager doesn't seem
       # able to find and use an appropriate version of ChromeDriver
       - name: Install Legacy Chrome
+        if: runner.os == 'Linux'
         uses: browser-actions/setup-chrome@latest
         with:
-          chrome-version: 1135568
+          chrome-version: 1135561
+
+      - name: Install Legacy Chrome
+        if: runner.os == 'macOS'
+        uses: browser-actions/setup-chrome@latest
+        with:
+          chrome-version: 1135562
+
+      - name: Install Legacy Chrome
+        if: runner.os == 'Windows'
+        uses: browser-actions/setup-chrome@latest
+        with:
+          chrome-version: 1135559
 
       #- name: Install ChromeDriver
       #  uses: nanasess/setup-chromedriver@v2

--- a/.github/workflows/apps-test-os.yml
+++ b/.github/workflows/apps-test-os.yml
@@ -121,10 +121,17 @@ jobs:
           format: "json"
           filter: "*"
 
-      - name: Install ChromeDriver
-        uses: nanasess/setup-chromedriver@v2
+      # Temporarily install Chrome 114.0.5735.331 since shinyjster's webdrivermanager doesn't seem
+      # able to find and use an appropriate version of ChromeDriver
+      - name: Install Legacy Chrome
+        uses: browser-actions/setup-chrome@latest
         with:
-          chromedriver-version: '116.0.5845.96'
+          chrome-version: 1177917
+
+      #- name: Install ChromeDriver
+      #  uses: nanasess/setup-chromedriver@v2
+      #  with:
+      #    chromedriver-version: '116.0.5845.96'
 
       - name: R Options
         shell: bash

--- a/.github/workflows/apps-test-os.yml
+++ b/.github/workflows/apps-test-os.yml
@@ -121,12 +121,12 @@ jobs:
           format: "json"
           filter: "*"
 
-      # Temporarily install Chrome 114.0.5735.331 since shinyjster's webdrivermanager doesn't seem
+      # Temporarily install Chrome 114.0.5735.134 since shinyjster's webdrivermanager doesn't seem
       # able to find and use an appropriate version of ChromeDriver
       - name: Install Legacy Chrome
         uses: browser-actions/setup-chrome@latest
         with:
-          chrome-version: 1177917
+          chrome-version: 1135568
 
       #- name: Install ChromeDriver
       #  uses: nanasess/setup-chromedriver@v2

--- a/.github/workflows/apps-test-os.yml
+++ b/.github/workflows/apps-test-os.yml
@@ -121,31 +121,6 @@ jobs:
           format: "json"
           filter: "*"
 
-      # Temporarily install Chrome 114.0.5735.134 since shinyjster's webdrivermanager doesn't seem
-      # able to find and use an appropriate version of ChromeDriver
-      - name: Install Legacy Chrome
-        if: runner.os == 'Linux'
-        uses: browser-actions/setup-chrome@latest
-        with:
-          chrome-version: 1135561
-
-      - name: Install Legacy Chrome
-        if: runner.os == 'macOS'
-        uses: browser-actions/setup-chrome@latest
-        with:
-          chrome-version: 1135562
-
-      - name: Install Legacy Chrome
-        if: runner.os == 'Windows'
-        uses: browser-actions/setup-chrome@latest
-        with:
-          chrome-version: 1135559
-
-      #- name: Install ChromeDriver
-      #  uses: nanasess/setup-chromedriver@v2
-      #  with:
-      #    chromedriver-version: '116.0.5845.96'
-
       - name: R Options
         shell: bash
         run: |

--- a/.github/workflows/apps-test-os.yml
+++ b/.github/workflows/apps-test-os.yml
@@ -121,6 +121,11 @@ jobs:
           format: "json"
           filter: "*"
 
+      - name: Install ChromeDriver
+        uses: nanasess/setup-chromedriver@v2
+        with:
+          chromedriver-version: '116.0.5845.96'
+
       - name: R Options
         shell: bash
         run: |

--- a/inst/apps/001-hello/app.R
+++ b/inst/apps/001-hello/app.R
@@ -1,5 +1,6 @@
 ### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
 
+
 library(shiny)
 
 # Define UI for app that draws a histogram ----


### PR DESCRIPTION
Attempts to fix error of the form:

```
pxjava - Caused by: org.openqa.selenium.SessionNotCreatedException: session not created: This version of ChromeDriver only supports Chrome version 114
pxjava - Current browser version is 116.0.5845.96 with binary path /usr/bin/google-chrome
```