### PR TITLE
Also set default colors for the accordion's active button

### DIFF
--- a/inst/apps/306-accordion-add-remove/app.R
+++ b/inst/apps/306-accordion-add-remove/app.R
@@ -7,7 +7,9 @@ ui <- page_sidebar(
     # Don't transition when collapsing (so screenshot timing is less of an issue)
     "transition-collapse" = "none",
     "accordion-bg" = "#1E1E1E",
+    "accordion-button-active-bg" = "#1E1E1E",
     "accordion-color" = "white",
+    "accordion-button-active-color" = "white",
     "accordion-icon-color" = "white",
     "accordion-icon-active-color" = "white"
   ) %>%

--- a/inst/apps/306-accordion-add-remove/app.R
+++ b/inst/apps/306-accordion-add-remove/app.R
@@ -9,6 +9,7 @@ ui <- page_sidebar(
     "accordion-bg" = "#1E1E1E",
     "accordion-button-active-bg" = "#1E1E1E",
     "accordion-color" = "white",
+    "accordion-button-color" = "white",
     "accordion-button-active-color" = "white",
     "accordion-icon-color" = "white",
     "accordion-icon-active-color" = "white"


### PR DESCRIPTION
Merging since this'll fix up some stylistic things, but it should still fail (for now) until [#3889](https://github.com/rstudio/shiny/issues/3889) is fixed