### PR TITLE
Bring back terra install workaround for windows+R<4.1

### DIFF
--- a/inst/apps/001-hello/app.R
+++ b/inst/apps/001-hello/app.R
@@ -1,5 +1,6 @@
 ### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
 
+
 library(shiny)
 
 # Define UI for app that draws a histogram ----

--- a/inst/gha/gha-adjust-packages-to-install.R
+++ b/inst/gha/gha-adjust-packages-to-install.R
@@ -14,10 +14,24 @@ adjust_pkgs <- function(pkgs_to_install = "rstudio/shiny,rstudio/bslib", r_versi
       }
   }
 
-  # Current dev version of terra has a fix that makes it installable on R<4.1
-  if (as.package_version(r_version) < as.package_version("4.1")) {
-    replace_or_add("any::terra", "rspatial/terra")
+  if (is_windows) {
+    # terra can't be built from source on Windows + R<4.1
+    switch(short_r_version,
+      "4.0" = {
+        replace_or_add("any::terra", "url::https://cloud.r-project.org/bin/windows/contrib/4.0/terra_1.5-21.zip")
+      },
+      "3.6" = {
+        replace_or_add("any::terra", "url::https://cloud.r-project.org/bin/windows/contrib/3.6/terra_1.2-5.zip")
+      }
+    )
+  } else {
+    # Current dev version of terra has a fix that makes it installable on R<4.1
+    if (as.package_version(r_version) < as.package_version("4.1")) {
+      replace_or_add("any::terra", "rspatial/terra")
+    }
   }
+
+  
 
   if (is_linux) {
     switch(short_r_version,


### PR DESCRIPTION
Follow up to #221. I had overlooked the fact that the workaround removed there is still relevant for Windows