### PR TITLE
fix(309): Use wide-enough screen size

### DIFF
--- a/inst/apps/309-flexdashboard-tabs-navs/tests/testthat/test-309-flexdashboard-tabs-navs.R
+++ b/inst/apps/309-flexdashboard-tabs-navs/tests/testthat/test-309-flexdashboard-tabs-navs.R
@@ -23,8 +23,8 @@ for (bs_version in 3:5) {
     app <- AppDriver$new(
       name = "309-flexdashboard-tabs-navs",
       seed = 62868,
-      height = 1292,
-      width = 798,
+      height = 600,
+      width = 1200,
       view = interactive(),
       render_args = list(
         params = list(bs_version = bs_version),


### PR DESCRIPTION
https://github.com/rstudio/bslib/pull/845 changes the breakpoint at which the navbar collapses in BS5, but these tests assumed the screen was wide enough to see the full navbar.

Fixes #228 