### PR TITLE
feat(render-results): Close all result logs by default

### DIFF
--- a/render-results.Rmd
+++ b/render-results.Rmd
@@ -368,7 +368,6 @@ bad_app_tags <-
           display_logs$r_version[[1]]
         )
         tags$details(
-          open = NA,
           tags$summary(platform, id = id),
           tags$code(tags$pre(res))
         )


### PR DESCRIPTION
This PR changes the `<details>` elements used for test result logs to be closed by default. They'll still open if you click on the red bubbles, but I find it's much easier to orient myself to the problems in a particular test when I can see the structure (which variants are failing) before opening up a variant to zoom in.

| Closed | Open |
|:---:|:---:|
| ![rstudio_shinycoreci results_ 2023-10-14 - 2023-10-24 (1)](https://github.com/rstudio/shinycoreci/assets/5420529/c5d99272-e02f-4cca-8948-7815da1135cb) | ![rstudio_shinycoreci results_ 2023-10-14 - 2023-10-24](https://github.com/rstudio/shinycoreci/assets/5420529/02d5a3d8-cf9a-4820-825b-1b3a8d1f91b8) |
