### PR TITLE
fix: Use `any(nzchar(x))` instead of `nchar(x) > 0`

### DIFF
--- a/R/test-in-browser.R
+++ b/R/test-in-browser.R
@@ -38,10 +38,10 @@ test_in_browser <- function(
         return()
       }
       proc_output_lines <- app_proc$read_output_lines()
-      if (any(nchar(proc_output_lines) > 0)) {
+      if (any(nzchar(proc_output_lines))) {
         output_lines_val <<- paste0(
           output_lines_val,
-          if (nchar(output_lines_val) > 0) "\n",
+          if (nzchar(output_lines_val)) "\n",
           paste0(proc_output_lines, collapse = "\n")
         )
       }

--- a/R/test-in-sso.R
+++ b/R/test-in-sso.R
@@ -197,7 +197,7 @@ test_in_ssossp <- function(
       return("")
     }
     out <- docker_proc$read_output_lines()
-    if (length(out) > 0 && nchar(out) > 0) {
+    if (length(out) > 0 && any(nzchar(out))) {
       paste0(out, collapse = "\n")
     } else {
       ""
@@ -218,7 +218,7 @@ test_in_ssossp <- function(
       Sys.sleep(0.5) # arbitrary, but it'll be a while till the docker is launched
       # display all docker output
       out <- get_docker_output()
-      if (nchar(out) > 0) {
+      if (any(nzchar(out))) {
         cat(out, "\n", sep = "")
       }
       invisible()
@@ -248,10 +248,10 @@ test_in_ssossp <- function(
           return("(dead)")
         }
         docker_proc_output_lines <- docker_proc$read_output_lines()
-        if (any(nchar(docker_proc_output_lines) > 0)) {
+        if (any(nzchar(docker_proc_output_lines))) {
           output_lines <<- paste0(
             output_lines,
-            if (nchar(output_lines) > 0) "\n",
+            if (nzchar(output_lines)) "\n",
             paste0(docker_proc_output_lines, collapse = "\n")
           )
         }


### PR DESCRIPTION
Fixes one instance where `any(nzchar())` is needed (missing `any()`) and then switches to `nzchar()` over `nchar()`.