### PR TITLE
306: Add screenshot threshold and some non-screenshot tests

### DIFF
--- a/inst/apps/063-superzip-example/tests/testthat/test-mytest.R
+++ b/inst/apps/063-superzip-example/tests/testthat/test-mytest.R
@@ -26,7 +26,7 @@ test_that("Migrated shinytest test: mytest.R", {
   }
 
   app$expect_values()
-  app$expect_screenshot()
+  app$expect_screenshot(threshold = 5)
   app$set_inputs(threshold = 3)
   app$set_inputs(color = "college")
 
@@ -38,7 +38,7 @@ test_that("Migrated shinytest test: mytest.R", {
     cat("\n\n")
   }
   app$expect_values()
-  app$expect_screenshot()
+  app$expect_screenshot(threshold = 5)
 
   app$set_inputs(nav = "Data explorer")
 
@@ -49,7 +49,7 @@ test_that("Migrated shinytest test: mytest.R", {
     cat("\n\n")
   }
   app$expect_values()
-  app$expect_screenshot()
+  app$expect_screenshot(threshold = 5)
 
   # Input 'ziptable_rows_current' was set, but doesn't have an input binding.
   # Input 'ziptable_rows_all' was set, but doesn't have an input binding.
@@ -64,5 +64,5 @@ test_that("Migrated shinytest test: mytest.R", {
     cat("\n\n")
   }
   app$expect_values()
-  app$expect_screenshot()
+  app$expect_screenshot(threshold = 5)
 })

--- a/inst/apps/306-accordion-add-remove/tests/testthat/test-306-accordion-add-remove.R
+++ b/inst/apps/306-accordion-add-remove/tests/testthat/test-306-accordion-add-remove.R
@@ -22,20 +22,52 @@ test_that("{shinytest2} recording: accordion-select", {
     app$wait_for_idle()
   }
 
+  set_selected <- function(x, expected = x) {
+    app$
+      set_inputs(selected = x)$
+      wait_for_idle()
+
+    expect_selected(expected)
+  }
+
+  expect_selected <- function(x) {
+    expect_equal(app$get_value(input = "selected"), !!x)
+  }
+
+  set_displayed <- function(x) {
+    app$
+      set_inputs(displayed = x)$
+      wait_for_idle()
+
+    displayed <- app$get_js(
+      "[...document.querySelectorAll('#acc .accordion-item')].map(el => el.dataset.value)"
+    )
+    displayed <- unlist(displayed)
+    expect_equal(displayed, x)
+  }
+
   # Test accordion_panel_set()
-  set_inputs(selected = c("A", "D"))
-  set_inputs(selected = c("A", "D", "H"))
+  set_selected(c("A", "D"))
+  set_selected(c("A", "D", "H"))
   app$expect_screenshot(threshold = 5)
 
   # Test accordion_panel_remove()
-  set_inputs(displayed = c("D", "F"))
+  set_displayed(c("D", "F"))
+  expect_selected("D")
+
   # Test accordion_panel_insert()
-  set_inputs(displayed = c("A", "D", "F"))
-  set_inputs(displayed = c("A", "D", "F", "Z"))
+  set_displayed(c("A", "D", "F"))
+  expect_selected("D")
+  set_displayed(c("A", "D", "F", "Z"))
+  expect_selected("D")
+
   # Test accordion_panel_insert() + accordion_panel_open()
   set_inputs(open_on_insert = TRUE)
-  set_inputs(displayed = c("A", "D", "F", "J", "Z"))
-  set_inputs(displayed = c("A", "D", "F", "J", "K", "Z"))
+  set_displayed(c("A", "D", "F", "J", "Z"))
+  expect_selected(c("D", "J"))
+
+  set_displayed(c("A", "D", "F", "J", "K", "Z"))
+  expect_selected(c("D", "J", "K"))
   app$expect_screenshot(threshold = 5)
 
   # redo tests with accordion(autoclose = TRUE)
@@ -43,13 +75,19 @@ test_that("{shinytest2} recording: accordion-select", {
   set_inputs(multiple = FALSE)
 
   # Last one (D) should be selected
-  set_inputs(selected = "B")
-  set_inputs(selected = c("C", "D"))
+  set_selected("B", expected = "B")
+  set_selected(c("C", "D"), expected = "D")
   app$expect_screenshot(threshold = 5)
 
-  set_inputs(displayed = c("A", "D", "F", "Z"))
+  set_displayed(c("A", "D", "F", "Z"))
+  expect_selected("D")
+
+  # Inserting a new open panel with multiple=FALSE selects just that panel
   set_inputs(open_on_insert = TRUE)
-  set_inputs(displayed = c("A", "D", "F", "J", "Z"))
-  set_inputs(displayed = c("A", "D", "F", "J", "K", "Z"))
+  set_displayed(c("A", "D", "F", "J", "Z"))
+  expect_selected("J")
+
+  set_displayed(c("A", "D", "F", "J", "K", "Z"))
+  expect_selected("K")
   app$expect_screenshot(threshold = 5)
 })

--- a/inst/apps/306-accordion-add-remove/tests/testthat/test-306-accordion-add-remove.R
+++ b/inst/apps/306-accordion-add-remove/tests/testthat/test-306-accordion-add-remove.R
@@ -25,7 +25,7 @@ test_that("{shinytest2} recording: accordion-select", {
   # Test accordion_panel_set()
   set_inputs(selected = c("A", "D"))
   set_inputs(selected = c("A", "D", "H"))
-  app$expect_screenshot()
+  app$expect_screenshot(threshold = 5)
 
   # Test accordion_panel_remove()
   set_inputs(displayed = c("D", "F"))
@@ -36,7 +36,7 @@ test_that("{shinytest2} recording: accordion-select", {
   set_inputs(open_on_insert = TRUE)
   set_inputs(displayed = c("A", "D", "F", "J", "Z"))
   set_inputs(displayed = c("A", "D", "F", "J", "K", "Z"))
-  app$expect_screenshot()
+  app$expect_screenshot(threshold = 5)
 
   # redo tests with accordion(autoclose = TRUE)
   set_inputs(open_on_insert = FALSE)
@@ -45,11 +45,11 @@ test_that("{shinytest2} recording: accordion-select", {
   # Last one (D) should be selected
   set_inputs(selected = "B")
   set_inputs(selected = c("C", "D"))
-  app$expect_screenshot()
+  app$expect_screenshot(threshold = 5)
 
   set_inputs(displayed = c("A", "D", "F", "Z"))
   set_inputs(open_on_insert = TRUE)
   set_inputs(displayed = c("A", "D", "F", "J", "Z"))
   set_inputs(displayed = c("A", "D", "F", "J", "K", "Z"))
-  app$expect_screenshot()
+  app$expect_screenshot(threshold = 5)
 })


### PR DESCRIPTION
* Adds `threshold = 5` to screenshot tests in `306-accordion-add-remove`
* Also adds direct testing of input and accordion state so we're not relying entirely on screenshots
* Similarly adds a threshold to the superzip screenshots