### PR TITLE
Get r-release mac running again

### DIFF
--- a/.github/workflows/apps-test-matrix.yml
+++ b/.github/workflows/apps-test-matrix.yml
@@ -29,7 +29,7 @@ jobs:
     needs: [config, ubuntu-release]
     uses: ./.github/workflows/apps-test-os.yml
     with:
-      r-version: ${{ needs.config.outputs.release }}
+      r-version: 4.3.1
       os: ${{ needs.config.outputs.macos }}
       cache-version: ${{ needs.config.outputs.cache-version }}
     secrets:


### PR DESCRIPTION
This temporary change is intended just to get the `r-release` tests running on Mac.

R 4.3.2 was released just yesterday, and the [binaries for Mac aren't yet available](https://cran.r-project.org/bin/macosx/)