### PR TITLE
feat: Add `inform_latest_results()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,8 @@ Suggests:
     tidyr,
     later,
     withr,
-    shinytest
+    shinytest,
+    chromote
 Config/Needs/website: tidyverse/tidytemplate
 URL: https://github.com/rstudio/shinycoreci
 BugReports: https://github.com/rstudio/shinycoreci/issues


### PR DESCRIPTION
A small helper to list the currently failing tests from the latest nightly run.

```r
pkgload::load_all()

inform_latest_results()
#> <https://rstudio.github.io/shinycoreci/results/2023/12/07/>
#> ✖ 6 tests failed:
#> - `145-dt-replacedata`
#> - `178-delayed-widget`
#> - `180-delayed-staticwidget`
#> - `301-bs-themes`
#> - `308-sidebar-kitchen-sink`
#> - `313-bslib-card-tab-focus`
```