### PR TITLE
Only capture differences to inst/apps when generating patch files in fix_snaps()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Core shiny team tools to facilitate testing of the shiny-verse.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Imports:
     jsonlite,
     progress,

--- a/R/fix_snaps.R
+++ b/R/fix_snaps.R
@@ -103,7 +103,7 @@ fix_snaps <- function(
 
       # Make patch file given diff
       # git_cmd_(paste0("git format-patch '", original_git_branch, "' --stdout > ", patch_file))
-      git_cmd_("git diff --binary ", original_git_branch, " > ", patch_file)
+      git_cmd_("git diff --binary ", original_git_branch, " -- inst/apps > ", patch_file)
     }
 
     patch_file


### PR DESCRIPTION
Ran into this when trying to debug errors in the `git apply` call in `fix_snaps()`. When debugging `git diff` was capturing changes I had made to `R/`, which was causing more errors in `git apply`, and isn't relevant for snapshots