### PR TITLE
Remove static mac deps to be installed

### DIFF
--- a/.github/internal/install-shinyverse/action.yaml
+++ b/.github/internal/install-shinyverse/action.yaml
@@ -67,4 +67,4 @@ runs:
       if: runner.os == 'macOS'
       uses: rstudio/shiny-workflows/setup-macOS-dependencies@v1
       with:
-        extra-packages: ${{ steps.mac-deps.outputs.pkgs }}
+        extra-packages: ${{ steps.mac-deps.outputs.pkgs }} Cairo FreeType RMySQL textshaping units

--- a/.github/internal/install-shinyverse/action.yaml
+++ b/.github/internal/install-shinyverse/action.yaml
@@ -67,4 +67,4 @@ runs:
       if: runner.os == 'macOS'
       uses: rstudio/shiny-workflows/setup-macOS-dependencies@v1
       with:
-        extra-packages: ${{ steps.mac-deps.outputs.pkgs }} terra Cairo FreeType RMySQL textshaping units
+        extra-packages: ${{ steps.mac-deps.outputs.pkgs }}

--- a/inst/apps/001-hello/app.R
+++ b/inst/apps/001-hello/app.R
@@ -1,5 +1,6 @@
 ### Keep this line to manually test this shiny application. Do not edit this line; shinycoreci::::is_manual_app
 
+
 library(shiny)
 
 # Define UI for app that draws a histogram ----


### PR DESCRIPTION
Currently mac takes 3+ hours to install. This is too long.

By removing `terra` which installs `gdal` with `brew`, install time should be faster. 

Leaflet apps may break. 🤷 