### PR TITLE
tests: Add 317-nav-insert

### DIFF
--- a/R/data-apps-deps.R
+++ b/R/data-apps-deps.R
@@ -174,7 +174,7 @@ apps_deps_map <- list(
   `314-bslib-tooltips` = c("bsicons", "bslib", "plotly", "shiny", "shinycoreci", "shinytest2", "withr"),
   `315-bslib-input-switch` = c("bslib", "shiny", "shinytest2", "withr"),
   `316-bslib-popovers` = c("bsicons", "bslib", "plotly", "rversions", "shiny", "shinycoreci", "shinytest2", "testthat", "withr"),
-  `317-nav-insert` = c("bslib", "leaflet", "rversions", "shiny", "shinycoreci", "shinytest2", "testthat", "withr"),
+  `317-nav-insert` = c("bslib", "htmltools", "leaflet", "rversions", "shiny", "shinycoreci", "shinytest2", "testthat", "withr"),
   `900-text-jster` = c("shiny", "shinyjster", "shinytest2"),
   `901-button-jster` = c("shiny", "shinyjster", "shinytest2")
 )

--- a/R/data-apps-deps.R
+++ b/R/data-apps-deps.R
@@ -174,6 +174,7 @@ apps_deps_map <- list(
   `314-bslib-tooltips` = c("bsicons", "bslib", "plotly", "shiny", "shinycoreci", "shinytest2", "withr"),
   `315-bslib-input-switch` = c("bslib", "shiny", "shinytest2", "withr"),
   `316-bslib-popovers` = c("bsicons", "bslib", "plotly", "rversions", "shiny", "shinycoreci", "shinytest2", "testthat", "withr"),
+  `317-nav-insert` = c("bslib", "leaflet", "rversions", "shiny", "shinycoreci", "shinytest2", "testthat", "withr"),
   `900-text-jster` = c("shiny", "shinyjster", "shinytest2"),
   `901-button-jster` = c("shiny", "shinyjster", "shinytest2")
 )

--- a/inst/apps/317-nav-insert/app.R
+++ b/inst/apps/317-nav-insert/app.R
@@ -1,0 +1,239 @@
+library(shiny)
+library(bslib)
+
+DO_ALERT <- FALSE
+
+action_choices <- c(
+  "Singleton script" = "singleton",
+  "Scripts with singleton" = "scripts",
+  "HTML Widget" = "htmlwidgets",
+  "Input/Output (content)" = "input_output_content",
+  "Input/Output (nav)" = "input_output_nav",
+  "Shiny sub-app" = "subapp"
+)
+
+ui <- page_navbar(
+  title = "Reprex for #4179",
+  id = "main",
+  lang = "en",
+  navbar_options = navbar_options(collapsible = FALSE),
+  footer = absolutePanel(
+    card(
+      selectInput("insert_type", "Insert nav type", choices = action_choices),
+      actionButton("do_insert", "Insert Nav"),
+      HTML(
+        '<p>Scripts: <span id="script-count">0</span> evaluated (<span id="script-count-expected">0</span> expected).'
+      ),
+      tags$script(
+        HTML(
+          "Shiny.addCustomMessageHandler('script-count-expected', function(value) {
+            const exp = document.getElementById('script-count-expected')
+            exp.textContent = +exp.textContent + value;
+          })"
+        )
+      )
+    ),
+    bottom = "1rem",
+    right = "1rem",
+    draggable = TRUE
+  )
+)
+
+# https://github.com/rstudio/shiny/pull/1794#issuecomment-318722200
+# We need these test cases for anywhere we insert dynamic UI:
+
+# 1. `<script>` blocks should run
+# 2. `<script>` blocks should only run once
+# 3. `head()`/`singleton()` should be respected
+# 4. HTML widgets should work
+# 	a. Even when the dependencies are not part of the initial page load
+# 5. Shiny inputs/outputs should work
+# 6. Subapps should work (include a `shinyApp` object right in the UI)
+
+action_link <- shiny::actionLink("refresh", "Refresh")
+
+script_hello_world <- local({
+  i <- 0
+
+  function() {
+    i <<- i + 1
+
+    shiny::HTML(
+      "<script>(function() {
+        const el = document.getElementById('script-count')
+        el.textContent = +el.textContent + 1
+      })()</script>"
+    )
+  }
+})
+
+script_singleton <- shiny::singleton(script_hello_world())
+
+singleton_has_run <- FALSE
+
+nav_insert_singleton <- function(session) {
+  if (!singleton_has_run) {
+    session$sendCustomMessage('script-count-expected', 1L)
+    singleton_has_run <<- TRUE
+  }
+
+  nav_insert(
+    id = "main",
+    select = TRUE,
+    nav_panel(
+      "One",
+      p("Script should only run the first time this nav is inserted."),
+      # 1. script blocks should run
+      script_singleton,
+      # 3. head() should be respected
+      tags$head(tags$meta(content = "shiny-test-head"))
+    ),
+  )
+}
+
+nav_insert_scripts <- function(session) {
+  session$sendCustomMessage('script-count-expected', 2L)
+
+  nav_insert(
+    id = "main",
+    select = TRUE,
+    nav_panel(
+      value = "Two",
+      tagList(
+        "Two",
+        script_hello_world(),
+      ),
+      p(
+        "Two scripts should run every time this nav is inserted."
+      ),
+      # 2. script blocks should only run once
+      script_hello_world()
+    ),
+  )
+}
+
+nav_insert_htmlwidget <- local({
+  widget_count <- 0
+  function() {
+    widget_count <<- widget_count + 1
+    # 4. htmlwidgets work even if not part of initial page load
+    nav_insert(
+      id = "main",
+      select = TRUE,
+      nav_panel(
+        "Map",
+        leaflet::addTiles(
+          leaflet::leaflet(
+            elementId = sprintf("leaflet-%d", widget_count)
+          )
+        )
+      ),
+    )
+  }
+})
+
+nav_insert_input_output_content <- function(input, output) {
+  # 5. Input/outputs should work (in content)
+  nav_insert(
+    id = "main",
+    select = TRUE,
+    nav_panel(
+      "Inputs/outputs",
+      layout_columns(
+        actionButton("btn", "Click me"),
+        sliderInput("slider", "Slide me", min = 0, max = 10, value = 2),
+      ),
+      verbatimTextOutput("debug")
+    )
+  )
+
+  output$debug <- renderPrint({
+    list(
+      btn = input$btn,
+      slider = input$slider,
+      nav_link = input$nav_link
+    )
+  })
+}
+
+nav_insert_input_output_nav <- function(input, output) {
+  # 5. Inputs/outputs work (in navbar)
+  nav_insert(
+    id = "main",
+    nav_item(
+      actionLink("nav_link", "Click me too", class = "nav-link")
+    )
+  )
+
+  nav_insert(
+    id = "main",
+    nav_item(textOutput("nav_output"))
+  )
+
+  output$nav_output <- renderText({
+    sprintf("Clicked %d times", input$nav_link)
+  })
+}
+
+nav_insert_subapp <- function() {
+  # 6. Shiny subapps
+  nav_insert(
+    id = "main",
+    select = TRUE,
+    nav_panel(
+      "Shiny app",
+      p("There should be another shiny app in here."),
+      shinyApp(
+        ui = page_fluid(
+          theme = bs_theme(preset = "darkly"),
+          titlePanel("Hello from in here!"),
+          p("This is a sub-app. Notice we're re-using the btn id."),
+          actionButton("btn", "Click me"),
+          verbatimTextOutput("debug")
+        ),
+        server = function(input, output, session) {
+          output$debug <- renderPrint(list(btn = input$btn))
+        }
+      )
+    )
+  )
+}
+
+server <- function(input, output, session) {
+  choices <- reactiveVal(action_choices)
+
+  observe({
+    updateSelectInput(
+      session,
+      "insert_type",
+      choices = choices(),
+      selected = input$insert_type
+    )
+  })
+
+  observeEvent(input$do_insert, {
+    one_time_choice <- FALSE
+
+    switch(
+      input$insert_type,
+      "singleton" = nav_insert_singleton(session),
+      "scripts" = nav_insert_scripts(session),
+      "htmlwidgets" = nav_insert_htmlwidget(),
+      "input_output_content" = {
+        one_time_choice <- TRUE
+        nav_insert_input_output_content(input, output)
+      },
+      "input_output_nav" = {
+        one_time_choice <- TRUE
+        nav_insert_input_output_nav(input, output)
+      },
+      "subapp" = nav_insert_subapp()
+    )
+
+    if (one_time_choice) {
+      choices(choices()[choices() != input$insert_type])
+    }
+  })
+}
+
+shinyApp(ui, server)

--- a/inst/apps/317-nav-insert/tests/testthat.R
+++ b/inst/apps/317-nav-insert/tests/testthat.R
@@ -1,0 +1,1 @@
+shinytest2::test_app()

--- a/inst/apps/317-nav-insert/tests/testthat/setup-shinytest2.R
+++ b/inst/apps/317-nav-insert/tests/testthat/setup-shinytest2.R
@@ -1,0 +1,3 @@
+# Load application support files into testing environment
+shinytest2::load_app_env()
+

--- a/inst/apps/317-nav-insert/tests/testthat/test-317-nav-insert.R
+++ b/inst/apps/317-nav-insert/tests/testthat/test-317-nav-insert.R
@@ -1,0 +1,207 @@
+library(shinytest2)
+if (FALSE) library(shinycoreci) # for renv
+
+# Only take screenshots on mac + r-release to reduce diff noise
+release <- rversions::r_release()$version
+release <- paste0(
+  strsplit(release, ".", fixed = TRUE)[[1]][1:2],
+  collapse = "."
+)
+
+is_testing_on_ci <- identical(Sys.getenv("CI"), "true") &&
+  testthat::is_testing()
+is_mac_release <- identical(paste0("mac-", release), platform_variant())
+
+DO_SCREENSHOT <- is_testing_on_ci && is_mac_release
+
+expect_js <- function(app, js, label = NULL) {
+  expect_true(
+    app$wait_for_js(!!js)$get_js(!!js),
+    label = label
+  )
+  invisible(app)
+}
+
+shiny_button_value <- function(x) {
+  structure(x, class = c("shinyActionButtonValue", "integer"))
+}
+
+# Setup App  --------------------------------------------------
+app <- AppDriver$new(
+  name = "317-nav-insert",
+  variant = platform_variant(),
+  height = 800,
+  width = 1200,
+  seed = 20230724,
+  view = interactive(),
+  options = list(bslib.precompiled = FALSE),
+  expect_values_screenshot_args = FALSE,
+  screenshot_args = list(selector = "viewport", delay = 0.5)
+)
+withr::defer(app$stop())
+
+# Setup App state and utility functions ------------------------
+test_that("An inserted script runs only once", {
+  app$set_inputs(insert_type = "singleton", wait_ = FALSE)$click("do_insert")
+
+  expect_js(
+    app,
+    "document.querySelectorAll('.tab-pane[data-value=\"One\"]').length === 1"
+  )
+
+  expect_equal(app$get_text("#script-count"), "1")
+  expect_equal(
+    app$get_text('#script-count'),
+    app$get_text("#script-count-expected")
+  )
+})
+
+test_that("A singleton script runs only once", {
+  app$set_inputs(insert_type = "singleton", wait_ = FALSE)$click("do_insert")
+
+  expect_js(
+    app,
+    "document.querySelectorAll('.tab-pane[data-value=\"One\"]').length === 2"
+  )
+
+  expect_equal(app$get_text("#script-count"), "1")
+  expect_equal(
+    app$get_text('#script-count'),
+    app$get_text("#script-count-expected")
+  )
+})
+
+test_that("Scripts in nav and content run once", {
+  app$set_inputs(insert_type = "scripts")$click("do_insert")
+
+  expect_js(
+    app,
+    "document.querySelectorAll('.tab-pane[data-value=\"Two\"]').length === 1"
+  )
+
+  expect_equal(app$get_text("#script-count"), "3")
+  expect_equal(
+    app$get_text('#script-count'),
+    app$get_text("#script-count-expected")
+  )
+})
+
+test_that("htmlwidgets are loaded via nav_insert()", {
+  expect_js(
+    app,
+    "typeof window.LeafletWidget === 'undefined'"
+  )
+
+  app$set_inputs(insert_type = "htmlwidgets")$click("do_insert")
+
+  expect_js(
+    app,
+    "typeof window.LeafletWidget !== 'undefined'"
+  )
+  expect_js(
+    app,
+    "document.getElementById('leaflet-1').classList.contains('leaflet')"
+  )
+  expect_js(
+    app,
+    "document.getElementById('leaflet-1').classList.contains('html-widget-static-bound')"
+  )
+})
+
+test_that("input/output in content area", {
+  # inputs/outputs don't exist yet
+  expect_equal(
+    unname(app$get_values(input = c("btn", "slider", "nav_link"))$input),
+    list()
+  )
+  expect_equal(
+    unname(app$get_values(output = "debug")$output),
+    list()
+  )
+
+  app$set_inputs(insert_type = "input_output_content")
+  app$click("do_insert")
+  app$click("btn")
+  app$set_inputs(slider = 5)
+
+  expect_equal(
+    app$get_values(input = c("btn", "slider", "nav_link"))$input,
+    list(
+      btn = shiny_button_value(1L),
+      slider = 5
+    )
+  )
+
+  app$expect_values(
+    input = c("btn", "slider", "nav_link"),
+    output = "debug"
+  )
+})
+
+test_that("input/output in nav area", {
+  # inputs/outputs don't exist yet
+  expect_equal(
+    unname(app$get_values(input = c("nav_link"))$input),
+    list()
+  )
+  expect_equal(
+    unname(app$get_values(output = "nav_output")$output),
+    list()
+  )
+
+  app$set_inputs(insert_type = "input_output_nav")
+  app$click("do_insert")
+  app$click("nav_link")
+  app$click("nav_link")
+
+  expect_equal(
+    app$get_values(input = c("btn", "slider", "nav_link"))$input,
+    list(
+      btn = shiny_button_value(1),
+      nav_link = shiny_button_value(2),
+      slider = 5
+    )
+  )
+
+  app$expect_values(
+    input = c("btn", "slider", "nav_link"),
+    output = c("debug", "nav_output")
+  )
+})
+
+test_that("subapps", {
+  app$set_inputs(insert_type = "subapp")
+  app$click("do_insert")
+
+  expect_js(
+    app,
+    'document.querySelector(\'.tab-pane[data-value="Shiny app"] iframe.shiny-frame\') !== null'
+  )
+  # Wait for inner app to be idle
+  expect_js(
+    app,
+    "document.querySelector('.shiny-frame').contentWindow.document.getElementById('btn') !== null"
+  )
+
+  outer_btn_before <- app$get_values()$input$btn
+
+  app$run_js(
+    "const iframe = document.querySelector('.shiny-frame').contentWindow.document
+    iframe.getElementById('btn').click()"
+  )
+  Sys.sleep(1)
+  inner_debug <- app$get_js(
+    "const iframe = document.querySelector('.shiny-frame').contentWindow.document
+    iframe.getElementById('debug').innerHTML"
+  )
+  expect_equal(
+    strsplit(inner_debug, "\n")[[1]][1:2],
+    c("$btn", "[1] 1")
+  )
+
+  # Iframed app is separate from parent app
+  expect_equal(
+    app$get_values()$input$btn,
+    outer_btn_before
+  )
+})

--- a/inst/apps/317-nav-insert/tests/testthat/test-317-nav-insert.R
+++ b/inst/apps/317-nav-insert/tests/testthat/test-317-nav-insert.R
@@ -205,3 +205,22 @@ test_that("subapps", {
     outer_btn_before
   )
 })
+
+test_that("web components are connected once", {
+  app$set_inputs(insert_type = "init_component")
+  app$click("do_insert")
+
+  expect_js(
+    app,
+    "document.querySelectorAll('init-component').length === 3"
+  )
+
+  expect_equal(
+    app$get_html("init-component"),
+    c(
+      "<init-component>Component</init-component>",
+      "<init-component>default</init-component>",
+      "<init-component>custom init text</init-component>"
+    )
+  )
+})

--- a/inst/apps/317-nav-insert/wc-init.js
+++ b/inst/apps/317-nav-insert/wc-init.js
@@ -1,0 +1,21 @@
+class InitComponent extends window.HTMLElement {
+  constructor() {
+    super();
+    
+    this.text = "default";
+  }
+
+  connectedCallback() {
+    if (this.hasAttribute("init")) {
+        this.text = this.getAttribute("init");
+        this.removeAttribute("init");
+    }
+    this.render()
+  }
+
+  render() {
+    this.innerText = this.text;
+  }
+}
+
+window.customElements.define("init-component", InitComponent);


### PR DESCRIPTION
Tests https://github.com/rstudio/shiny/pull/4179 and the additional cases the `shiny-insert-tab` message handler should cover in particular (from https://github.com/rstudio/shiny/pull/1794#issuecomment-318722200):

> We need these test cases for anywhere we insert dynamic UI:
> 
> 1. `<script>` blocks should run
> 2. `<script>` blocks should only run once
> 3. `head()`/`singleton()` should be respected
> 4. HTML widgets should work
> 	a. Even when the dependencies are not part of the initial page load
> 5. Shiny inputs/outputs should work
> 6. Subapps should work (include a `shinyApp` object right in the UI)


I also included a test that involves a custom element that modifies its attributes in its connected callback. For this kind of custom element, `shiny-insert-tab` would render the HTML twice, causing the final inserted UI not to match what the user expected. This was fixed by the linked shiny PR.