### PR TITLE
feat: Add `ide_open_app()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,7 @@ Description: Core shiny team tools to facilitate testing of the shiny-verse.
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Imports:
     jsonlite,
     progress,

--- a/R/test-in-ide.R
+++ b/R/test-in-ide.R
@@ -186,3 +186,25 @@ test_in_ide <- function(
     }
   )
 }
+
+ide_open_app <- function(app_name) {
+  app_name <- resolve_app_name(app_name)
+  owd <- setwd(app_path(app_name))
+  cli::cli_alert("Opening app {.field {app_name}}")
+  cli::cli_alert_info("App location: {.path {app_path(app_name)}}")
+
+  app_files <- dir(pattern = "(app|ui).[Rr]")
+  server_files <- dir(pattern = "server.[Rr]")
+  test_files <- dir("tests/testthat", pattern = "test-", full.names = TRUE)
+
+  files <- vapply(
+    c(app_files, server_files, test_files),
+    function(x) sprintf("{.path %s}", x),
+    character(1)
+  )
+
+  cli::cli_h3("Test app files")
+  cli::cli_ol(files)
+
+  invisible(owd)
+}


### PR DESCRIPTION
Adds an internal helper function to quickly open an app and move into the app's working directory.

![image](https://github.com/user-attachments/assets/ce48e0df-f4b0-4c04-91d9-19b175457323)

The purple code are clickable links that open the files directly. Note that you don't need to know the full app name, the app number is sufficient (thanks to existing helpers!).