### PR TITLE
chore: Set screenshot threshold and kernel_size for all tests

### DIFF
--- a/.github/workflows/apps-test-os.yml
+++ b/.github/workflows/apps-test-os.yml
@@ -139,6 +139,13 @@ jobs:
           WDM_GITHUBTOKENSECRET: ${{ secrets.GITHUB_TOKEN }}
         shell: Rscript {0}
         run: |
+          # Allow for a 10% difference in the screenshot kernel
+          # 62.5 / (3x RGB channels * 25 * 25) = 62.5 / 625 = 10%
+          options(
+            shinytest2.compare_screenshot.threshold = 62.5,
+            shinytest2.compare_screenshot.kernel_size = 25
+          )
+          
           apps <- shinycoreci:::apps_with_tests()
           is_pull_request <- isTRUE(jsonlite::parse_json("${{ github.event_name == 'pull_request' }}"))
           if (is_pull_request) {


### PR DESCRIPTION
Following the logic in 301-bs-themes tests but with smaller kernel size

https://github.com/rstudio/shinycoreci/blob/33c0862bf6c94a6e8793fb32881c298876aa90ee/inst/apps/301-bs-themes/tests/testthat/test-themes.R#L82-L84