### PR TITLE
feat: Use `chrome-headless-shell` for chromote-based checks

### DIFF
--- a/.github/workflows/apps-test-os.yml
+++ b/.github/workflows/apps-test-os.yml
@@ -134,11 +134,11 @@ jobs:
         run: |
           pak::repo_add("https://rstudio.r-universe.dev")
           pak::pak("chromote", upgrade = TRUE)
-          
+
           path <- chromote::chrome_versions_add("latest-stable", binary = "chrome-headless-shell")
           cat(
             sprintf("\nCHROMOTE_CHROME=%s\n", path),
-            Sys.getenv("GITHUB_ENV"),
+            file = Sys.getenv("GITHUB_ENV"),
             append = TRUE
           )
 

--- a/.github/workflows/apps-test-os.yml
+++ b/.github/workflows/apps-test-os.yml
@@ -132,9 +132,6 @@ jobs:
         id: setup_chromote  
         shell: Rscript {0}
         run: |
-          pak::repo_add("https://rstudio.r-universe.dev")
-          pak::pak("chromote", upgrade = TRUE)
-
           path <- chromote::chrome_versions_add("latest-stable", binary = "chrome-headless-shell")
           cat(
             sprintf("\nCHROMOTE_CHROME=%s\n", path),

--- a/.github/workflows/apps-test-os.yml
+++ b/.github/workflows/apps-test-os.yml
@@ -128,6 +128,17 @@ jobs:
         run: |
           cat("name=gha-", '${{ steps.failed_branch.outputs.name }}', '-', '${{ steps.short.outputs.r-version }}', '-', '${{ runner.os }}', "\n", file = Sys.getenv("GITHUB_OUTPUT"), sep = "", append = TRUE)
 
+      - name: Use chrome-headless-shell@latest-stable
+        id: setup_chromote  
+        shell: Rscript {0}
+        run: |
+          path <- chromote::chrome_versions_add("latest-stable", binary = "chrome-headless-shell")
+          cat(
+            sprintf("\nCHROMOTE_CHROME=%s\n", path),
+            Sys.getenv("GITHUB_ENV"),
+            append = TRUE
+          )
+
       # Install packages as necessary!
       - name: Run tests
         timeout-minutes: 180 # 3 hrs

--- a/.github/workflows/apps-test-os.yml
+++ b/.github/workflows/apps-test-os.yml
@@ -132,6 +132,9 @@ jobs:
         id: setup_chromote  
         shell: Rscript {0}
         run: |
+          pak::repo_add("https://rstudio.r-universe.dev")
+          pak::pak("chromote", upgrade = TRUE)
+          
           path <- chromote::chrome_versions_add("latest-stable", binary = "chrome-headless-shell")
           cat(
             sprintf("\nCHROMOTE_CHROME=%s\n", path),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,7 @@ URL: https://github.com/rstudio/shinycoreci
 BugReports: https://github.com/rstudio/shinycoreci/issues
 Imports:
     callr,
+    chromote (>= 0.4.0.9000),
     cli,
     jsonlite,
     progress,
@@ -24,7 +25,6 @@ Imports:
     utils,
     withr
 Suggests:
-    chromote (>= 0.4.0),
     dplyr,
     english,
     httpuv,
@@ -39,6 +39,8 @@ Suggests:
     tibble,
     tidyr,
     waldo
+Remotes: 
+    rstudio/chromote
 Config/Needs/website: tidyverse/tidytemplate
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
Downloads the latest stable release of `chrome-headless-shell` and then sets `CHROMOTE_CHROME` to that path so that it is used (for tests that rely on chromote) instead of the system installation of Chrome.