### PR TITLE
fix(test): skip tests for all OS for `200-flexdashboard-render-text` app

### DIFF
--- a/inst/apps/200-flexdashboard-render-text/tests/testthat/test-shinyjster.R
+++ b/inst/apps/200-flexdashboard-render-text/tests/testthat/test-shinyjster.R
@@ -1,3 +1,3 @@
-skip_if(.Platform$OS.type != "windows")
+skip("Skipping flexdashboard-render-text tests for all OS")
 
 shinyjster::testthat_shinyjster()


### PR DESCRIPTION
This pull request updates the test skipping logic in the `test-shinyjster.R` file for the `200-flexdashboard-render-text` app to apply to all operating systems instead of just non-Windows systems.
