### PR TITLE
Update selector in tooltip focus test

### DIFF
--- a/inst/apps/314-bslib-tooltips/tests/testthat/test-314-bslib-tooltips.R
+++ b/inst/apps/314-bslib-tooltips/tests/testthat/test-314-bslib-tooltips.R
@@ -89,8 +89,8 @@ test_that("Can tab focus various cases/options", {
 
   key_press("Tab")
   key_press("Tab")
-  expect_focus(app, "#btn3")
-  expect_visible_tip(app, "#btn3")
+  expect_focus(app, "#tip-multiple > :last-child")
+  expect_visible_tip(app, "#tip-multiple > :last-child")
 
   # Options ----------------------------------
   key_press("Tab")

--- a/inst/apps/314-bslib-tooltips/tests/testthat/test-314-bslib-tooltips.R
+++ b/inst/apps/314-bslib-tooltips/tests/testthat/test-314-bslib-tooltips.R
@@ -89,8 +89,8 @@ test_that("Can tab focus various cases/options", {
 
   key_press("Tab")
   key_press("Tab")
-  expect_focus(app, "#tip-multiple :last-child")
-  expect_visible_tip(app, "#tip-multiple :last-child")
+  expect_focus(app, "#btn3")
+  expect_visible_tip(app, "#btn3")
 
   # Options ----------------------------------
   key_press("Tab")


### PR DESCRIPTION
Replaces the generic ':last-child' selector with the specific '#btn3' selector in tooltip focus and visibility tests for improved accuracy.