### PR TITLE
Fix external workflow run lookup

### DIFF
--- a/.github/internal/external-package-check/action.yaml
+++ b/.github/internal/external-package-check/action.yaml
@@ -132,26 +132,29 @@ runs:
           bot_login="${APP_SLUG}[bot]"
         fi
 
+        selector_args=(
+          --dispatched-at "${DISPATCHED_AT}"
+          --target-ref "${TARGET_REF}"
+        )
+
+        if [[ -n "${bot_login}" ]]; then
+          selector_args+=(--bot-login "${bot_login}")
+        fi
+
+        workflow_id="$(gh api \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "/repos/${TARGET_OWNER}/${TARGET_REPO}/actions/workflows/${TARGET_WORKFLOW}" \
+          --jq '.id')"
+
         run_id=""
         for _ in $(seq 1 "${LOOKUP_ATTEMPTS}"); do
           response="$(gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/repos/${TARGET_OWNER}/${TARGET_REPO}/actions/workflows/${TARGET_WORKFLOW}/runs?event=workflow_dispatch&branch=${TARGET_REF}&per_page=20")"
+            "/repos/${TARGET_OWNER}/${TARGET_REPO}/actions/workflows/${workflow_id}/runs?per_page=50")"
 
-          run_id="$(jq -r \
-            --arg dispatched_at "${DISPATCHED_AT}" \
-            --arg bot_login "${bot_login}" \
-            '[
-              .workflow_runs[]
-              | select(.created_at >= $dispatched_at)
-            ]
-            | sort_by(.created_at)
-            | (
-                map(select(($bot_login != "") and ((.triggering_actor.login // .actor.login // "") == $bot_login)))
-                | first
-              ) // first
-            | .id // empty' <<<"${response}")"
+          run_id="$(bash "${GITHUB_ACTION_PATH}/select-workflow-run.sh" "${selector_args[@]}" <<<"${response}")"
 
           [[ -n "${run_id}" ]] && break
           sleep "${LOOKUP_INTERVAL}"

--- a/.github/internal/external-package-check/select-workflow-run.sh
+++ b/.github/internal/external-package-check/select-workflow-run.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+dispatched_at=""
+target_ref=""
+bot_login=""
+
+while (($# > 0)); do
+  case "$1" in
+    --dispatched-at)
+      dispatched_at="$2"
+      shift 2
+      ;;
+    --target-ref)
+      target_ref="$2"
+      shift 2
+      ;;
+    --bot-login)
+      bot_login="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "${dispatched_at}" || -z "${target_ref}" ]]; then
+  echo "--dispatched-at and --target-ref are required." >&2
+  exit 1
+fi
+
+jq -r \
+  --arg dispatched_at "${dispatched_at}" \
+  --arg target_ref "${target_ref}" \
+  --arg bot_login "${bot_login}" \
+  '[
+    .workflow_runs[]
+    | select(.created_at >= $dispatched_at)
+    | select(.event == "workflow_dispatch")
+    | select(.head_branch == $target_ref)
+  ]
+  | sort_by(.created_at)
+  | (
+      map(select(($bot_login != "") and ((.triggering_actor.login // .actor.login // "") == $bot_login)))
+      | first
+    ) // first
+  | .id // empty'

--- a/.github/internal/external-package-check/test-select-workflow-run.sh
+++ b/.github/internal/external-package-check/test-select-workflow-run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+action_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+selected_run_id="$(bash "${action_dir}/select-workflow-run.sh" \
+  --dispatched-at "2026-04-27T19:46:53Z" \
+  --target-ref "main" \
+  --bot-login "posit-shiny-automation[bot]" \
+  < "${action_dir}/testdata/workflow-runs.json")"
+
+if [[ "${selected_run_id}" != "25015944788" ]]; then
+  echo "Expected run 25015944788, got ${selected_run_id:-<empty>}." >&2
+  exit 1
+fi

--- a/.github/internal/external-package-check/testdata/workflow-runs.json
+++ b/.github/internal/external-package-check/testdata/workflow-runs.json
@@ -1,0 +1,64 @@
+{
+  "workflow_runs": [
+    {
+      "id": 25015944788,
+      "created_at": "2026-04-27T19:46:55Z",
+      "event": "workflow_dispatch",
+      "head_branch": "main",
+      "actor": {
+        "login": "posit-shiny-automation[bot]"
+      },
+      "triggering_actor": {
+        "login": "posit-shiny-automation[bot]"
+      }
+    },
+    {
+      "id": 25015944790,
+      "created_at": "2026-04-27T19:46:56Z",
+      "event": "pull_request",
+      "head_branch": "main",
+      "actor": {
+        "login": "other-user"
+      },
+      "triggering_actor": {
+        "login": "other-user"
+      }
+    },
+    {
+      "id": 25015944791,
+      "created_at": "2026-04-27T19:46:57Z",
+      "event": "workflow_dispatch",
+      "head_branch": "feature-branch",
+      "actor": {
+        "login": "posit-shiny-automation[bot]"
+      },
+      "triggering_actor": {
+        "login": "posit-shiny-automation[bot]"
+      }
+    },
+    {
+      "id": 25015944792,
+      "created_at": "2026-04-27T19:46:58Z",
+      "event": "workflow_dispatch",
+      "head_branch": "main",
+      "actor": {
+        "login": "other-user"
+      },
+      "triggering_actor": {
+        "login": "other-user"
+      }
+    },
+    {
+      "id": 25015944770,
+      "created_at": "2026-04-27T19:46:52Z",
+      "event": "workflow_dispatch",
+      "head_branch": "main",
+      "actor": {
+        "login": "posit-shiny-automation[bot]"
+      },
+      "triggering_actor": {
+        "login": "posit-shiny-automation[bot]"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- resolve the target workflow to its numeric workflow ID before polling
- list recent runs without server-side event/branch filters and select the dispatched run client-side
- add a regression fixture and shell test for the selector helper

## Validation
- bash .github/internal/external-package-check/test-select-workflow-run.sh
- gh api 'repos/rstudio/reactlog/actions/workflows/1449174/runs?per_page=50' | bash .github/internal/external-package-check/select-workflow-run.sh --dispatched-at '2026-04-27T19:46:53Z' --target-ref main --bot-login 'posit-shiny-automation[bot]'