### PR TITLE
Fix devtools::check() notes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -22,3 +22,4 @@ www/nvd3/deprecated
 ^README_files$
 ^_gh-pages$
 ^_dev$
+^\.context$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Imports:
     utils,
     withr
 Suggests:
-    cli,
     dplyr,
     english,
     httpuv,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,6 @@ Suggests:
     tidyr,
     waldo
 Config/Needs/website: tidyverse/tidytemplate
+Config/roxygen2/version: 8.0.0
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-Config/roxygen2/version: 8.0.0

--- a/R/accept_snaps.R
+++ b/R/accept_snaps.R
@@ -48,7 +48,7 @@ accept_snaps <- function(
 
         NULL
       })
-      ignore <- capture.output(
+      ignore <- utils::capture.output(
         type = "message",
         {
           testthat::snapshot_accept()
@@ -70,7 +70,7 @@ accept_snaps <- function(
         cli::cli_li("{.file {name}}: {format(diff, nsmall = 2)}")
       })
       cli::cli_end(ul)
-      hist(snaps_diffs, main = "Histogram of snapshot diffs", xlab = "shinytest2::screenshot_max_difference()")
+      graphics::hist(snaps_diffs, main = "Histogram of snapshot diffs", xlab = "shinytest2::screenshot_max_difference()")
     }
   }
 

--- a/R/deploy-apps.R
+++ b/R/deploy-apps.R
@@ -98,8 +98,8 @@ deploy_apps <- function(
           try({
             withr::with_tempdir({
               rsconnect::writeManifest(app_dir)
-              cat(paste0(readLines(file.path(appDir, "manifest.json")), collapse = "\n"), "\n")
-              unlink(file.path(appDir, "manifest.json"))
+              cat(paste0(readLines(file.path(app_dir, "manifest.json")), collapse = "\n"), "\n")
+              unlink(file.path(app_dir, "manifest.json"))
             })
           })
           return(1)

--- a/R/install.R
+++ b/R/install.R
@@ -160,7 +160,7 @@ get_extra_shinyverse_deps <- function(packages) {
     if (is.null(pkg_dep_packages)) {
       # Install pak if not already installed
       if (!requireNamespace("pak", quietly = TRUE)) {
-        install.packages("pak")
+        utils::install.packages("pak")
       }
 
       withr::with_options(
@@ -271,7 +271,7 @@ install_pkgs_with_callr <- function(
 
       # Install pak if not already installed
       if (!requireNamespace("pak", quietly = TRUE)) {
-        install.packages("pak")
+        utils::install.packages("pak")
       }
 
       # Performing a leap of faith that pak is installed.


### PR DESCRIPTION
## Summary

`devtools::check()` was reporting 3 NOTEs; this clears them all (now `0 errors | 0 warnings | 0 notes`):

- Add `^\.context$` to `.Rbuildignore` so the Conductor workspace dir doesn't trigger the hidden-files NOTE.
- Remove duplicate `cli` from `Suggests` (it's already in `Imports`).
- Qualify global function calls: `utils::capture.output`, `utils::install.packages`, `graphics::hist`.
- Fix an undefined `appDir` reference in the `rsconnect` debug path of `deploy_apps()` (should be `app_dir`).

## Test plan

- [x] `devtools::check()` returns `0 errors | 0 warnings | 0 notes`